### PR TITLE
Add policy support for creating / deleting warrants

### DIFF
--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -107,7 +107,17 @@ public class WarrantBaseClient {
 
     public boolean check(WarrantObject object, String relation, WarrantSubject subject) throws WarrantException {
         WarrantCheckSpec toCheck = new WarrantCheckSpec(
-                Arrays.asList(new Warrant(object.type(), object.id(), relation, subject)));
+                Arrays.asList(new WarrantSpec(object.type(), object.id(), relation, subject)));
+        WarrantCheck result = makePostRequest("/v2/authorize", toCheck, WarrantCheck.class);
+        if (result.getCode().intValue() == 200 && "Authorized".equals(result.getResult())) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean check(WarrantObject object, String relation, WarrantSubject subject, Map<String, Object> context) throws WarrantException {
+        WarrantCheckSpec toCheck = new WarrantCheckSpec(
+                Arrays.asList(new WarrantSpec(object.type(), object.id(), relation, subject, context)));
         WarrantCheck result = makePostRequest("/v2/authorize", toCheck, WarrantCheck.class);
         if (result.getCode().intValue() == 200 && "Authorized".equals(result.getResult())) {
             return true;

--- a/src/main/java/dev/warrant/model/Warrant.java
+++ b/src/main/java/dev/warrant/model/Warrant.java
@@ -6,6 +6,7 @@ public class Warrant {
     private String objectId;
     private String relation;
     private WarrantSubject subject;
+    private String policy;
     private boolean isImplicit;
 
     public Warrant() {
@@ -17,6 +18,14 @@ public class Warrant {
         this.objectId = objectId;
         this.relation = relation;
         this.subject = subject;
+    }
+
+    public Warrant(String objectType, String objectId, String relation, WarrantSubject subject, String policy) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.relation = relation;
+        this.subject = subject;
+        this.policy = policy;
     }
 
     public Warrant(String objectType, String objectId, String relation, WarrantSubject subject, boolean isImplicit) {
@@ -41,6 +50,10 @@ public class Warrant {
 
     public WarrantSubject getSubject() {
         return subject;
+    }
+
+    public String getPolicy() {
+        return policy;
     }
 
     public boolean getIsImplicit() {

--- a/src/main/java/dev/warrant/model/WarrantCheckSpec.java
+++ b/src/main/java/dev/warrant/model/WarrantCheckSpec.java
@@ -3,28 +3,28 @@ package dev.warrant.model;
 import java.util.List;
 
 public class WarrantCheckSpec {
-    
-    private List<Warrant> warrants;
+
+    private List<WarrantSpec> warrants;
     private String op;
 
     public WarrantCheckSpec() {
         // For json serialization
     }
 
-    public WarrantCheckSpec(List<Warrant> warrants, String op) {
+    public WarrantCheckSpec(List<WarrantSpec> warrants, String op) {
         this.warrants = warrants;
         this.op = op;
     }
 
-    public WarrantCheckSpec(List<Warrant> warrants) {
+    public WarrantCheckSpec(List<WarrantSpec> warrants) {
         this.warrants = warrants;
     }
 
-    public List<Warrant> getWarrants() {
+    public List<WarrantSpec> getWarrants() {
         return warrants;
     }
 
-    public void setWarrants(List<Warrant> warrants) {
+    public void setWarrants(List<WarrantSpec> warrants) {
         this.warrants = warrants;
     }
 

--- a/src/main/java/dev/warrant/model/WarrantSpec.java
+++ b/src/main/java/dev/warrant/model/WarrantSpec.java
@@ -1,0 +1,51 @@
+package dev.warrant.model;
+
+import java.util.Map;
+
+public class WarrantSpec {
+
+    private String objectType;
+    private String objectId;
+    private String relation;
+    private WarrantSubject subject;
+    private Map<String, Object> context;
+
+    public WarrantSpec() {
+        // For json serialization
+    }
+
+    public WarrantSpec(String objectType, String objectId, String relation, WarrantSubject subject) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.relation = relation;
+        this.subject = subject;
+    }
+
+    public WarrantSpec(String objectType, String objectId, String relation, WarrantSubject subject, Map<String, Object> context) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.relation = relation;
+        this.subject = subject;
+        this.context = context;
+    }
+
+    public String getObjectType() {
+        return objectType;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public String getRelation() {
+        return relation;
+    }
+
+    public WarrantSubject getSubject() {
+        return subject;
+    }
+
+    public Map<String, Object> getContext() {
+        return context;
+    }
+}

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -1,5 +1,8 @@
 package dev.warrant;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -427,5 +430,27 @@ public class LiveTest {
 
         client.deleteUser(newUser);
         client.deletePermission(newPermission);
+    }
+
+    @Test
+    public void warrantsWithPolicy() throws WarrantException {
+        User testUser = client.createUser(new User("test-user"));
+        Permission testPermission = client
+                .createPermission(new Permission("test-permission"));
+
+        client.createWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), "geo == 'us' && isActivated == true");
+        Map<String, Object> warrantContext = new HashMap<>();
+        warrantContext.put("geo", "us");
+        warrantContext.put("isActivated", true);
+        Assertions.assertTrue(client.check(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), warrantContext));
+
+        warrantContext.clear();
+        warrantContext.put("geo", "eu");
+        warrantContext.put("isActivated", false);
+        Assertions.assertFalse(client.check(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), warrantContext));
+
+        client.deleteWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), "geo == 'us' && isActivated == true");
+        client.deleteUser(testUser);
+        client.deletePermission(testPermission);
     }
 }


### PR DESCRIPTION
This PR adds support for creating and deleting warrants with a policy, as well as doing access checks with context.

Creating warrants with a policy:
```
User testUser = client.createUser(new User("test-user"));
Permission testPermission = client
        .createPermission(new Permission("test-permission"));

client.createWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), "geo == 'us' && isActivated == true");
```

Deleting warrants with a policy:
```
client.deleteWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), "geo == 'us' && isActivated == true");
```

Access check with context:
```
Map<String, Object> warrantContext = new HashMap<>();
warrantContext.put("geo", "us");
warrantContext.put("isActivated", true);
client.check(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()), warrantContext);

```