### PR TITLE
Add v2 api support

### DIFF
--- a/src/main/java/dev/warrant/ListParams.java
+++ b/src/main/java/dev/warrant/ListParams.java
@@ -4,21 +4,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ListParams {
-    private int page = 0;
     private int limit = 0;
-    private String beforeId;
-    private String beforeValue;
-    private String afterId;
-    private String afterValue;
+    private String prevCursor;
+    private String nextCursor;
     private String sortBy;
     private String sortOrder;
 
     public ListParams() {
-    }
-
-    public ListParams withPage(int page) {
-        this.page = page;
-        return this;
     }
 
     public ListParams withLimit(int limit) {
@@ -26,23 +18,13 @@ public class ListParams {
         return this;
     }
 
-    public ListParams withBeforeId(String beforeId) {
-        this.beforeId = beforeId;
+    public ListParams withPrevCursor(String prevCursor) {
+        this.prevCursor = prevCursor;
         return this;
     }
 
-    public ListParams withBeforeValue(String beforeValue) {
-        this.beforeValue = beforeValue;
-        return this;
-    }
-
-    public ListParams withAfterId(String afterId) {
-        this.afterId = afterId;
-        return this;
-    }
-
-    public ListParams withAfterValue(String afterValue) {
-        this.afterValue = afterValue;
+    public ListParams withNextCursor(String nextCursor) {
+        this.nextCursor = nextCursor;
         return this;
     }
 
@@ -58,23 +40,14 @@ public class ListParams {
 
     public Map<String, Object> asMap() {
         Map<String, Object> params = new HashMap<>();
-        if (this.page != 0) {
-            params.put("page", page);
-        }
         if (this.limit != 0) {
             params.put("limit", limit);
         }
-        if (this.beforeId != null) {
-            params.put("beforeId", beforeId);
+        if (this.prevCursor != null) {
+            params.put("prevCursor", prevCursor);
         }
-        if (this.beforeValue != null) {
-            params.put("beforeValue", beforeValue);
-        }
-        if (this.afterId != null) {
-            params.put("afterId", afterId);
-        }
-        if (this.afterValue != null) {
-            params.put("afterValue", afterValue);
+        if (this.nextCursor != null) {
+            params.put("nextCursor", nextCursor);
         }
         if (this.sortBy != null) {
             params.put("sortBy", sortBy);

--- a/src/main/java/dev/warrant/ObjectFilters.java
+++ b/src/main/java/dev/warrant/ObjectFilters.java
@@ -1,0 +1,34 @@
+package dev.warrant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ObjectFilters {
+
+    private String objectType = "";
+    private String objectId = "";
+
+    public ObjectFilters() {
+    }
+
+    public ObjectFilters withObjectType(String objectType) {
+        this.objectType = objectType;
+        return this;
+    }
+
+    public ObjectFilters withObjectId(String objectId) {
+        this.objectId = objectId;
+        return this;
+    }
+
+    public Map<String, Object> asMap() {
+        Map<String, Object> params = new HashMap<>();
+        if (!this.objectType.isEmpty()) {
+            params.put("objectType", objectType);
+        }
+        if (!this.objectId.isEmpty()) {
+            params.put("objectId", objectId);
+        }
+        return params;
+    }
+}

--- a/src/main/java/dev/warrant/ObjectFilters.java
+++ b/src/main/java/dev/warrant/ObjectFilters.java
@@ -6,7 +6,7 @@ import java.util.Map;
 public class ObjectFilters {
 
     private String objectType = "";
-    private String objectId = "";
+    private String query = "";
 
     public ObjectFilters() {
     }
@@ -16,8 +16,8 @@ public class ObjectFilters {
         return this;
     }
 
-    public ObjectFilters withObjectId(String objectId) {
-        this.objectId = objectId;
+    public ObjectFilters withQuery(String query) {
+        this.query = query;
         return this;
     }
 
@@ -26,8 +26,8 @@ public class ObjectFilters {
         if (!this.objectType.isEmpty()) {
             params.put("objectType", objectType);
         }
-        if (!this.objectId.isEmpty()) {
-            params.put("objectId", objectId);
+        if (!this.query.isEmpty()) {
+            params.put("q", query);
         }
         return params;
     }

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -25,6 +25,10 @@ import dev.warrant.model.WarrantCheckSpec;
 import dev.warrant.model.WarrantSpec;
 import dev.warrant.model.WarrantCheck;
 import dev.warrant.model.object.WarrantObject;
+import dev.warrant.model.object.BaseWarrantObject;
+import dev.warrant.model.object.BaseListResult;
+import dev.warrant.model.object.ListResult;
+import dev.warrant.model.object.WarrantListResult;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -66,7 +70,15 @@ public class WarrantBaseClient {
     public Warrant createWarrant(WarrantObject object, String relation, WarrantSubject subject, String policy, RequestOptions requestOptions)
             throws WarrantException {
             Warrant toCreate = new Warrant(object.type(), object.id(), relation, subject, policy);
-            return makePostRequest("/v1/warrants", toCreate, Warrant.class, requestOptions.asMap());
+            return makePostRequest("/v2/warrants", toCreate, Warrant.class, requestOptions.asMap());
+    }
+
+    public Warrant[] createWarrants(Warrant[] warrants) throws WarrantException {
+        return createWarrants(warrants, new RequestOptions());
+    }
+
+    public Warrant[] createWarrants(Warrant[] warrants, RequestOptions requestOptions) throws WarrantException {
+        return makePostRequest("/v2/warrants", warrants, Warrant[].class, requestOptions.asMap());
     }
 
     public void deleteWarrant(WarrantObject object, String relation, WarrantSubject subject) throws WarrantException {
@@ -82,19 +94,27 @@ public class WarrantBaseClient {
     }
 
     public void deleteWarrant(WarrantObject object, String relation, WarrantSubject subject, String policy, RequestOptions requestOptions) throws WarrantException {
-            Warrant toDelete = new Warrant(object.type(), object.id(), relation, subject, policy);
-            makeDeleteRequest("/v1/warrants", toDelete, requestOptions.asMap());
+        Warrant toDelete = new Warrant(object.type(), object.id(), relation, subject, policy);
+        makeDeleteRequest("/v2/warrants", toDelete, requestOptions.asMap());
     }
 
-    public Warrant[] listWarrants(WarrantFilters filters, ListParams listParams) throws WarrantException {
+    public void deleteWarrants(Warrant[] warrants) throws WarrantException {
+        deleteWarrants(warrants, new RequestOptions());
+    }
+
+    public void deleteWarrants(Warrant[] warrants, RequestOptions requestOptions) throws WarrantException {
+        makeDeleteRequest("/v2/warrants", warrants, requestOptions.asMap());
+    }
+
+    public WarrantListResult listWarrants(WarrantFilters filters, ListParams listParams) throws WarrantException {
         return listWarrants(filters, listParams, new RequestOptions());
     }
 
-    public Warrant[] listWarrants(WarrantFilters filters, ListParams listParams, RequestOptions requestOptions)
+    public WarrantListResult listWarrants(WarrantFilters filters, ListParams listParams, RequestOptions requestOptions)
             throws WarrantException {
         Map<String, Object> queryParams = filters.asMap();
         queryParams.putAll(listParams.asMap());
-        return makeGetRequest("/v1/warrants", queryParams, Warrant[].class, requestOptions.asMap());
+        return makeGetRequest("/v2/warrants", queryParams, WarrantListResult.class, requestOptions.asMap());
     }
 
     public QueryResultSet query(String query, ListParams listParams) throws WarrantException {
@@ -105,7 +125,7 @@ public class WarrantBaseClient {
             throws WarrantException {
         Map<String, Object> queryParams = listParams.asMap();
         queryParams.put("q", query);
-        return makeGetRequest("/v1/query", queryParams, QueryResultSet.class, requestOptions.asMap());
+        return makeGetRequest("/v2/query", queryParams, QueryResultSet.class, requestOptions.asMap());
     }
 
     public boolean check(WarrantObject object, String relation, WarrantSubject subject) throws WarrantException {
@@ -155,66 +175,162 @@ public class WarrantBaseClient {
         return checkWithOp(warrants, "allOf", WarrantCheck.class, new RequestOptions());
     }
 
-    // public BaseWarrantObject createObject(String objectType) throws WarrantException {
-    //     return createObject(objectType, null, Collections.emptyMap(), BaseWarrantObject.class);
-    // }
+    public BaseWarrantObject createObject(String objectType) throws WarrantException {
+        return createObject(objectType, null, Collections.emptyMap(), BaseWarrantObject.class, new RequestOptions());
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, Class<T> resultType) throws WarrantException {
-    //     return createObject(objectType, null, Collections.emptyMap(), resultType);
-    // }
+    public BaseWarrantObject createObject(String objectType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, null, Collections.emptyMap(), BaseWarrantObject.class, requestOptions);
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
-    //     return createObject(objectType, null, Collections.emptyMap(), resultType);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, Class<T> resultType) throws WarrantException {
+        return createObject(objectType, null, Collections.emptyMap(), resultType, new RequestOptions());
+    }
 
-    // public BaseWarrantObject createObject(String objectType, Map<String, Object> meta) throws WarrantException {
-    //     return createObject(objectType, null, meta, BaseWarrantObject.class);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, null, Collections.emptyMap(), resultType, requestOptions);
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
-    //     return createObject(objectType, null, meta, resultType);
-    // }
+    public BaseWarrantObject createObject(String objectType, Map<String, Object> meta) throws WarrantException {
+        return createObject(objectType, null, meta, BaseWarrantObject.class, new RequestOptions());
+    }
 
-    // public BaseWarrantObject createObject(String objectType, String objectId) throws WarrantException {
-    //     return createObject(objectType, objectId, Collections.emptyMap(), BaseWarrantObject.class);
-    // }
+    public BaseWarrantObject createObject(String objectType, Map<String, Object> meta, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, null, meta, BaseWarrantObject.class, requestOptions);
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, String objectId, Class<T> resultType) throws WarrantException {
-    //     return createObject(objectType, objectId, Collections.emptyMap(), resultType);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
+        return createObject(objectType, null, meta, resultType, new RequestOptions());
+    }
 
-    // public BaseWarrantObject createObject(String objectType, String objectId, Map<String, Object> meta) throws WarrantException {
-    //     return createObject(objectType, objectId, meta, BaseWarrantObject.class);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, Map<String, Object> meta, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, null, meta, resultType, requestOptions);
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
-    //     return createObject(objectType, objectId, meta, resultType, new RequestOptions());
-    // }
+    public BaseWarrantObject createObject(String objectType, String objectId) throws WarrantException {
+        return createObject(objectType, objectId, Collections.emptyMap(), BaseWarrantObject.class, new RequestOptions());
+    }
 
-    // public <T extends WarrantObject> T createObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
-    //     BaseWarrantObject obj = new BaseWarrantObject(objectType, objectId, meta);
-    //     return makePostRequest("/v1/objects", obj, resultType, requestOptions.asMap());
-    // }
+    public BaseWarrantObject createObject(String objectType, String objectId, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, objectId, Collections.emptyMap(), BaseWarrantObject.class, requestOptions);
+    }
 
-    // public BaseWarrantObject getObject(String objectType, String objectId) throws WarrantException {
-    //     return getObject(objectType, objectId, BaseWarrantObject.class);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, String objectId, Class<T> resultType) throws WarrantException {
+        return createObject(objectType, objectId, Collections.emptyMap(), resultType, new RequestOptions());
+    }
 
-    // public <T extends WarrantObject> T getObject(String objectType, String objectId, Class<T> resultType) throws WarrantException {
-    //     return makeGetRequest("/v1/objects/" + objectType + "/" + objectId, resultType);
-    // }
+    public <T extends WarrantObject> T createObject(String objectType, String objectId, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, objectId, Collections.emptyMap(), resultType, requestOptions);
+    }
 
-    // public BaseWarrantObject updateObject(String objectType, String objectId, Map<String, Object> meta) throws WarrantException {
-    //     BaseWarrantObject obj = new BaseWarrantObject(objectType, objectId, meta);
-    //     return makePutRequest("/v1/objects/" + objectType + "/" + objectId, obj, BaseWarrantObject.class);
-    // }
+    public BaseWarrantObject createObject(String objectType, String objectId, Map<String, Object> meta) throws WarrantException {
+        return createObject(objectType, objectId, meta, BaseWarrantObject.class, new RequestOptions());
+    }
+
+    public BaseWarrantObject createObject(String objectType, String objectId, Map<String, Object> meta, RequestOptions requestOptions) throws WarrantException {
+        return createObject(objectType, objectId, meta, BaseWarrantObject.class, requestOptions);
+    }
+
+    public <T extends WarrantObject> T createObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
+        return createObject(objectType, objectId, meta, resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T createObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        BaseWarrantObject obj = new BaseWarrantObject(objectType, objectId, meta);
+        return makePostRequest("/v2/objects", obj, resultType, requestOptions.asMap());
+    }
+
+    public BaseWarrantObject[] createObjects(BaseWarrantObject[] objects) throws WarrantException {
+        return createObjects(objects, new RequestOptions());
+    }
+
+    public BaseWarrantObject[] createObjects(BaseWarrantObject[] objects, RequestOptions requestOptions) throws WarrantException {
+        return createObjects(objects, BaseWarrantObject[].class, requestOptions);
+    }
+
+    public <T extends WarrantObject> T[] createObjects(T[] objects, Class<T[]> resultType) throws WarrantException {
+        return createObjects(objects, resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T[] createObjects(T[] objects, Class<T[]> resultType, RequestOptions requestOptions) throws WarrantException {
+        BaseWarrantObject[] baseObjects = Arrays.stream(objects).map(object -> new BaseWarrantObject(object.type(), object.id(), object.meta())).toArray(BaseWarrantObject[]::new);
+        return makePostRequest("/v2/objects", baseObjects, resultType, requestOptions.asMap());
+    }
+
+    public BaseWarrantObject getObject(String objectType, String objectId) throws WarrantException {
+        return getObject(objectType, objectId, BaseWarrantObject.class, new RequestOptions());
+    }
+
+    public BaseWarrantObject getObject(String objectType, String objectId, RequestOptions requestOptions) throws WarrantException {
+        return getObject(objectType, objectId, BaseWarrantObject.class, requestOptions);
+    }
+
+    public <T extends WarrantObject> T getObject(String objectType, String objectId, Class<T> resultType) throws WarrantException {
+        return getObject(objectType, objectId, resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T getObject(String objectType, String objectId, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return makeGetRequest("/v2/objects/" + objectType + "/" + objectId, resultType, requestOptions.asMap());
+    }
+
+    public BaseWarrantObject updateObject(String objectType, String objectId, Map<String, Object> meta) throws WarrantException {
+        return updateObject(objectType, objectId, meta, BaseWarrantObject.class, new RequestOptions());
+    }
+
+    public BaseWarrantObject updateObject(String objectType, String objectId, Map<String, Object> meta, RequestOptions requestOptions) throws WarrantException {
+        return updateObject(objectType, objectId, meta, BaseWarrantObject.class, requestOptions);
+    }
+
+    public <T extends WarrantObject> T updateObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
+        return updateObject(objectType, objectId, meta, resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T updateObject(String objectType, String objectId, Map<String, Object> meta, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        BaseWarrantObject obj = new BaseWarrantObject(objectType, objectId, meta);
+        return makePutRequest("/v2/objects/" + objectType + "/" + objectId, obj, resultType, requestOptions.asMap());
+    }
 
     public void deleteObject(WarrantObject obj) throws WarrantException {
-        deleteObject(obj.type(), obj.id());
+        deleteObject(obj.type(), obj.id(), new RequestOptions());
+    }
+
+    public void deleteObject(WarrantObject obj, RequestOptions requestOptions) throws WarrantException {
+        deleteObject(obj.type(), obj.id(), requestOptions);
     }
 
     public void deleteObject(String objectType, String objectId) throws WarrantException {
-        makeDeleteRequest("/v1/objects/" + objectType + "/" + objectId);
+        deleteObject(objectType, objectId, new RequestOptions());
+    }
+
+    public void deleteObject(String objectType, String objectId, RequestOptions requestOptions) throws WarrantException {
+        makeDeleteRequest("/v2/objects/" + objectType + "/" + objectId, requestOptions.asMap());
+    }
+
+    public void deleteObjects(BaseWarrantObject[] objects) throws WarrantException {
+        deleteObjects(objects, new RequestOptions());
+    }
+
+    public void deleteObjects(BaseWarrantObject[] objects, RequestOptions requestOptions) throws WarrantException {
+        makeDeleteRequest("/v2/objects", objects, requestOptions.asMap());
+    }
+
+    public <T extends WarrantObject> void deleteObjects(T[] objects) throws WarrantException {
+        deleteObjects(objects, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> void deleteObjects(T[] objects, RequestOptions requestOptions) throws WarrantException {
+        BaseWarrantObject[] baseObjects = Arrays.stream(objects).map(object -> new BaseWarrantObject(object.type(), object.id())).toArray(BaseWarrantObject[]::new);
+        makeDeleteRequest("/v2/objects", baseObjects, requestOptions.asMap());
+    }
+
+    public BaseListResult listObjects(ObjectFilters filters, ListParams listParams) throws WarrantException {
+        return listObjects(filters, listParams, new RequestOptions());
+    }
+
+    public BaseListResult listObjects(ObjectFilters filters, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        Map<String, Object> queryParams = filters.asMap();
+        queryParams.putAll(listParams.asMap());
+        return makeGetRequest("/v2/objects", queryParams, BaseListResult.class, requestOptions.asMap());
     }
 
     public String createUserAuthzSession(String userId) throws WarrantException {
@@ -222,7 +338,7 @@ public class WarrantBaseClient {
     }
 
     public String createUserAuthzSession(String userId, RequestOptions requestOptions) throws WarrantException {
-        UserSession sess = makePostRequest("/v1/sessions", UserSessionSpec.newAuthorizationSessionSpec(userId),
+        UserSession sess = makePostRequest("/v2/sessions", UserSessionSpec.newAuthorizationSessionSpec(userId),
                 UserSession.class, requestOptions.asMap());
         return sess.getToken();
     }
@@ -234,7 +350,7 @@ public class WarrantBaseClient {
 
     public String createUserSelfServiceDashboardUrl(String userId, String tenantId, String selfServiceStrategy, String redirectUrl, RequestOptions requestOptions)
             throws WarrantException {
-        UserSession ssdash = makePostRequest("/v1/sessions",
+        UserSession ssdash = makePostRequest("/v2/sessions",
                 UserSessionSpec.newSelfServiceDashboardSessionSpec(userId, tenantId, selfServiceStrategy),
                 UserSession.class, requestOptions.asMap());
         return config.getSelfServiceDashboardBaseUrl() + "/" + ssdash.getToken() + "?redirectUrl=" + redirectUrl;

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -27,7 +27,6 @@ import dev.warrant.model.WarrantCheck;
 import dev.warrant.model.object.WarrantObject;
 import dev.warrant.model.object.BaseWarrantObject;
 import dev.warrant.model.object.BaseListResult;
-import dev.warrant.model.object.ListResult;
 import dev.warrant.model.object.WarrantListResult;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -26,7 +26,7 @@ import dev.warrant.model.WarrantSpec;
 import dev.warrant.model.WarrantCheck;
 import dev.warrant.model.object.WarrantObject;
 import dev.warrant.model.object.BaseWarrantObject;
-import dev.warrant.model.object.BaseListResult;
+import dev.warrant.model.object.BaseWarrantObjectListResult;
 import dev.warrant.model.object.WarrantListResult;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -354,14 +354,14 @@ public class WarrantBaseClient {
         makeDeleteRequest("/v2/objects", baseObjects, requestOptions.asMap());
     }
 
-    public BaseListResult listObjects(ObjectFilters filters, ListParams listParams) throws WarrantException {
+    public BaseWarrantObjectListResult listObjects(ObjectFilters filters, ListParams listParams) throws WarrantException {
         return listObjects(filters, listParams, new RequestOptions());
     }
 
-    public BaseListResult listObjects(ObjectFilters filters, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public BaseWarrantObjectListResult listObjects(ObjectFilters filters, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         Map<String, Object> queryParams = filters.asMap();
         queryParams.putAll(listParams.asMap());
-        return makeGetRequest("/v2/objects", queryParams, BaseListResult.class, requestOptions.asMap());
+        return makeGetRequest("/v2/objects", queryParams, BaseWarrantObjectListResult.class, requestOptions.asMap());
     }
 
     public String createUserAuthzSession(String userId) throws WarrantException {

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -174,6 +174,38 @@ public class WarrantBaseClient {
         return checkWithOp(warrants, "allOf", WarrantCheck.class, new RequestOptions());
     }
 
+    public BaseWarrantObject createObject(BaseWarrantObject object) throws WarrantException {
+        return createObject(object, new RequestOptions());
+    }
+
+    public BaseWarrantObject createObject(BaseWarrantObject object, RequestOptions requestOptions) throws WarrantException {
+        return createObject(object.type(), object.id(), Collections.emptyMap(), requestOptions);
+    }
+
+    public BaseWarrantObject createObject(BaseWarrantObject object, Map<String, Object> meta) throws WarrantException {
+        return createObject(object, meta, new RequestOptions());
+    }
+
+    public BaseWarrantObject createObject(BaseWarrantObject object, Map<String, Object> meta, RequestOptions requestOptions) throws WarrantException {
+        return createObject(object.type(), object.id(), meta, requestOptions);
+    }
+
+    public <T extends WarrantObject> T createObject(T object, Class<T> resultType) throws WarrantException {
+        return createObject(object.type(), object.id(), Collections.emptyMap(), resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T createObject(T object, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(object.type(), object.id(), Collections.emptyMap(), resultType, requestOptions);
+    }
+
+    public <T extends WarrantObject> T createObject(T object, Map<String, Object> meta, Class<T> resultType) throws WarrantException {
+        return createObject(object.type(), object.id(), meta, resultType, new RequestOptions());
+    }
+
+    public <T extends WarrantObject> T createObject(T object, Map<String, Object> meta, Class<T> resultType, RequestOptions requestOptions) throws WarrantException {
+        return createObject(object.type(), object.id(), meta, resultType, requestOptions);
+    }
+
     public BaseWarrantObject createObject(String objectType) throws WarrantException {
         return createObject(objectType, null, Collections.emptyMap(), BaseWarrantObject.class, new RequestOptions());
     }

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -335,28 +335,40 @@ public class WarrantBaseClient {
         return makePutRequest("/v2/objects/" + objectType + "/" + objectId, obj, resultType, requestOptions.asMap());
     }
 
-    public void deleteObject(WarrantObject obj) throws WarrantException {
-        deleteObject(obj.type(), obj.id(), new RequestOptions());
+    public String deleteObject(WarrantObject obj) throws WarrantException {
+        return deleteObject(obj.type(), obj.id(), new RequestOptions());
     }
 
-    public void deleteObject(WarrantObject obj, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(obj.type(), obj.id(), requestOptions);
+    public String deleteObject(WarrantObject obj, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(obj.type(), obj.id(), requestOptions);
     }
 
-    public void deleteObject(String objectType, String objectId) throws WarrantException {
-        deleteObject(objectType, objectId, new RequestOptions());
+    public String deleteObject(String objectType, String objectId) throws WarrantException {
+        return deleteObject(objectType, objectId, new RequestOptions());
     }
 
-    public void deleteObject(String objectType, String objectId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v2/objects/" + objectType + "/" + objectId, requestOptions.asMap());
+    public String deleteObject(String objectType, String objectId, RequestOptions requestOptions) throws WarrantException {
+        HttpResponse<String> response = makeDeleteRequest("/v2/objects/" + objectType + "/" + objectId, requestOptions.asMap());
+        Optional<String> warrantToken = response.headers().firstValue("warrant-token");
+        if (warrantToken.isPresent()) {
+            return warrantToken.toString();
+        } else {
+            return "";
+        }
     }
 
-    public void deleteObjects(BaseWarrantObject[] objects) throws WarrantException {
-        deleteObjects(objects, new RequestOptions());
+    public String deleteObjects(BaseWarrantObject[] objects) throws WarrantException {
+        return deleteObjects(objects, new RequestOptions());
     }
 
-    public void deleteObjects(BaseWarrantObject[] objects, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v2/objects", objects, requestOptions.asMap());
+    public String deleteObjects(BaseWarrantObject[] objects, RequestOptions requestOptions) throws WarrantException {
+        HttpResponse<String> response = makeDeleteRequest("/v2/objects", objects, requestOptions.asMap());
+        Optional<String> warrantToken = response.headers().firstValue("warrant-token");
+        if (warrantToken.isPresent()) {
+            return warrantToken.toString();
+        } else {
+            return "";
+        }
     }
 
     public <T extends WarrantObject> void deleteObjects(T[] objects) throws WarrantException {

--- a/src/main/java/dev/warrant/WarrantBaseClient.java
+++ b/src/main/java/dev/warrant/WarrantBaseClient.java
@@ -248,7 +248,7 @@ public class WarrantBaseClient {
         try {
             String payload = mapper.writeValueAsString(toCheck);
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(config.getCheckUrl() + "/v2/authorize"))
+                    .uri(URI.create(config.getCheckUrl() + "/v2/check"))
                     .POST(HttpRequest.BodyPublishers.ofString(payload))
                     .header("User-Agent", USER_AGENT);
 
@@ -278,7 +278,7 @@ public class WarrantBaseClient {
             WarrantCheckSpec toCheck = new WarrantCheckSpec(warrants, op);
             String payload = mapper.writeValueAsString(toCheck);
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(config.getCheckUrl() + "/v2/authorize"))
+                    .uri(URI.create(config.getCheckUrl() + "/v2/check"))
                     .POST(HttpRequest.BodyPublishers.ofString(payload))
                     .header("User-Agent", USER_AGENT);
 

--- a/src/main/java/dev/warrant/WarrantClient.java
+++ b/src/main/java/dev/warrant/WarrantClient.java
@@ -1,16 +1,24 @@
 package dev.warrant;
 
 import java.net.http.HttpClient;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import dev.warrant.exception.WarrantException;
 import dev.warrant.model.WarrantSubject;
+import dev.warrant.model.object.BaseWarrantObject;
 import dev.warrant.model.object.Feature;
+import dev.warrant.model.object.BaseListResult;
+import dev.warrant.model.object.ListResult;
 import dev.warrant.model.object.Permission;
 import dev.warrant.model.object.PricingTier;
 import dev.warrant.model.object.Role;
 import dev.warrant.model.object.Tenant;
 import dev.warrant.model.object.User;
+import dev.warrant.model.QueryResult;
+import dev.warrant.model.QueryResultSet;
 import dev.warrant.model.Warrant;
 
 public class WarrantClient extends WarrantBaseClient {
@@ -29,7 +37,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public User createUser(RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/users", Collections.EMPTY_MAP, User.class, requestOptions.asMap());
+        return createObject(User.OBJECT_TYPE, User.class, requestOptions);
     }
 
     public User createUser(User user) throws WarrantException {
@@ -37,7 +45,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public User createUser(User user, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/users", user, User.class, requestOptions.asMap());
+        return createObject(User.OBJECT_TYPE, user.getUserId(), user.getMeta(), User.class, requestOptions);
     }
 
     public User[] createUsers(User[] users) throws WarrantException {
@@ -45,7 +53,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public User[] createUsers(User[] users, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/users", users, User[].class, requestOptions.asMap());
+        return createObjects(users, User[].class, requestOptions);
     }
 
     public User updateUser(String userId, User toUpdate) throws WarrantException {
@@ -53,7 +61,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public User updateUser(String userId, User toUpdate, RequestOptions requestOptions) throws WarrantException {
-        return makePutRequest("/v1/users/" + userId, toUpdate, User.class, requestOptions.asMap());
+        return updateObject(User.OBJECT_TYPE, userId, toUpdate.getMeta(), User.class, requestOptions);
     }
 
     public void deleteUser(User user) throws WarrantException {
@@ -65,7 +73,15 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deleteUser(String userId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/users/" + userId, requestOptions.asMap());
+        deleteObject(User.OBJECT_TYPE, userId, requestOptions);
+    }
+
+    public void deleteUsers(User[] users) throws WarrantException {
+        deleteObjects(users);
+    }
+
+    public void deleteUsers(User[] users, RequestOptions requestOptions) throws WarrantException {
+        deleteObjects(users, requestOptions);
     }
 
     public User getUser(String userId) throws WarrantException {
@@ -73,55 +89,59 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public User getUser(String userId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId, User.class, requestOptions.asMap());
+        return getObject(User.OBJECT_TYPE, userId, User.class, requestOptions);
     }
 
-    public User[] listUsers(int limit, int page) throws WarrantException {
-        return listUsers(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<User> listUsers(int limit) throws WarrantException {
+        return listUsers(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public User[] listUsers(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listUsers(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<User> listUsers(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listUsers(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public User[] listUsers(ListParams listParams) throws WarrantException {
+    public ListResult<User> listUsers(ListParams listParams) throws WarrantException {
         return listUsers(listParams, new RequestOptions());
     }
 
-    public User[] listUsers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users", listParams.asMap(), User[].class, requestOptions.asMap());
+    public ListResult<User> listUsers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult userObjects = listObjects(new ObjectFilters().withObjectType(User.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        User[] users = Arrays.stream(userObjects.getResults()).map(result -> new User(result.getObjectId(), result.getMeta())).toArray(User[]::new);
+        return new ListResult<User>(users, userObjects.getPrevCursor(), userObjects.getNextCursor());
     }
 
-    public User[] listUsersForTenant(Tenant tenant, int limit, int page) throws WarrantException {
-        return listUsersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<User> listUsersForTenant(Tenant tenant, int limit) throws WarrantException {
+        return listUsersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public User[] listUsersForTenant(Tenant tenant, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listUsersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<User> listUsersForTenant(Tenant tenant, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listUsersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public User[] listUsersForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
+    public ListResult<User> listUsersForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
         return listUsersForTenant(tenant.getTenantId(), listParams, new RequestOptions());
     }
 
-    public User[] listUsersForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<User> listUsersForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listUsersForTenant(tenant.getTenantId(), listParams, requestOptions);
     }
 
-    public User[] listUsersForTenant(String tenantId, int limit, int page) throws WarrantException {
-        return listUsersForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<User> listUsersForTenant(String tenantId, int limit) throws WarrantException {
+        return listUsersForTenant(tenantId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public User[] listUsersForTenant(String tenantId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listUsersForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<User> listUsersForTenant(String tenantId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listUsersForTenant(tenantId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public User[] listUsersForTenant(String tenantId, ListParams listParams) throws WarrantException {
+    public ListResult<User> listUsersForTenant(String tenantId, ListParams listParams) throws WarrantException {
         return listUsersForTenant(tenantId, listParams, new RequestOptions());
     }
 
-    public User[] listUsersForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/tenants/" + tenantId + "/users", listParams.asMap(), User[].class, requestOptions.asMap());
+    public ListResult<User> listUsersForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select * of type user for tenant:" + tenantId, listParams, requestOptions);
+        User[] users = Arrays.stream(queryResultSet.getResults()).map(result -> new User(result.getObjectId(), result.getMeta())).toArray(User[]::new);
+        return new ListResult<User>(users, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Tenants
@@ -138,7 +158,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Tenant createTenant(Tenant tenant, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/tenants", tenant, Tenant.class, requestOptions.asMap());
+        return createObject(Tenant.OBJECT_TYPE, tenant.getTenantId(), tenant.getMeta(), Tenant.class, requestOptions);
     }
 
     public Tenant[] createTenants(Tenant[] tenants) throws WarrantException {
@@ -146,7 +166,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Tenant[] createTenants(Tenant[] tenants, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/tenants", tenants, Tenant[].class, requestOptions.asMap());
+        return createObjects(tenants, Tenant[].class, requestOptions);
     }
 
     public Tenant updateTenant(String tenantId, Tenant toUpdate) throws WarrantException {
@@ -154,7 +174,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Tenant updateTenant(String tenantId, Tenant toUpdate, RequestOptions requestOptions) throws WarrantException {
-        return makePutRequest("/v1/tenants/" + tenantId, toUpdate, Tenant.class, requestOptions.asMap());
+        return updateObject(Tenant.OBJECT_TYPE, tenantId, toUpdate.getMeta(), Tenant.class, requestOptions);
     }
 
     public void deleteTenant(Tenant tenant) throws WarrantException {
@@ -170,7 +190,15 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deleteTenant(String tenantId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/tenants/" + tenantId, requestOptions.asMap());
+        deleteObject(Tenant.OBJECT_TYPE, tenantId, requestOptions);
+    }
+
+    public void deleteTenants(Tenant[] tenants) throws WarrantException {
+        deleteObjects(tenants);
+    }
+
+    public void deleteTenants(Tenant[] tenants, RequestOptions requestOptions) throws WarrantException {
+        deleteObjects(tenants, requestOptions);
     }
 
     public Tenant getTenant(String tenantId) throws WarrantException {
@@ -178,64 +206,76 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Tenant getTenant(String tenantId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/tenants/" + tenantId, Tenant.class, requestOptions.asMap());
+        return getObject(Tenant.OBJECT_TYPE, tenantId, Tenant.class, requestOptions);
     }
 
-    public Tenant[] listTenants(int limit, int page) throws WarrantException {
-        return listTenants(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Tenant> listTenants(int limit) throws WarrantException {
+        return listTenants(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Tenant[] listTenants(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listTenants(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Tenant> listTenants(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listTenants(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Tenant[] listTenants(ListParams listParams) throws WarrantException {
+    public ListResult<Tenant> listTenants(ListParams listParams) throws WarrantException {
         return listTenants(listParams, new RequestOptions());
     }
 
-    public Tenant[] listTenants(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/tenants", listParams.asMap(), Tenant[].class, requestOptions.asMap());
+    public ListResult<Tenant> listTenants(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult tenantObjects = listObjects(new ObjectFilters().withObjectType(Tenant.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        Tenant[] tenants = Arrays.stream(tenantObjects.getResults()).map(result -> new Tenant(result.getObjectId(), result.getMeta())).toArray(Tenant[]::new);
+        return new ListResult<Tenant>(tenants, tenantObjects.getPrevCursor(), tenantObjects.getNextCursor());
     }
 
-    public Tenant[] listTenantsForUser(User user, int limit, int page) throws WarrantException {
-        return listTenantsForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Tenant> listTenantsForUser(User user, int limit) throws WarrantException {
+        return listTenantsForUser(user.getUserId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Tenant[] listTenantsForUser(User user, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listTenantsForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Tenant> listTenantsForUser(User user, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listTenantsForUser(user.getUserId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Tenant[] listTenantsForUser(User user, ListParams listParams) throws WarrantException {
+    public ListResult<Tenant> listTenantsForUser(User user, ListParams listParams) throws WarrantException {
         return listTenantsForUser(user.getUserId(), listParams, new RequestOptions());
     }
 
-    public Tenant[] listTenantsForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Tenant> listTenantsForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listTenantsForUser(user.getUserId(), listParams, requestOptions);
     }
 
-    public Tenant[] listTenantsForUser(String userId, int limit, int page) throws WarrantException {
-        return listTenantsForUser(userId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Tenant> listTenantsForUser(String userId, int limit) throws WarrantException {
+        return listTenantsForUser(userId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Tenant[] listTenantsForUser(String userId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listTenantsForUser(userId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Tenant> listTenantsForUser(String userId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listTenantsForUser(userId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Tenant[] listTenantsForUser(String userId, ListParams listParams) throws WarrantException {
+    public ListResult<Tenant> listTenantsForUser(String userId, ListParams listParams) throws WarrantException {
         return listTenantsForUser(userId, listParams, new RequestOptions());
     }
 
-    public Tenant[] listTenantsForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId + "/tenants", listParams.asMap(), Tenant[].class, requestOptions.asMap());
+    public ListResult<Tenant> listTenantsForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select tenant where user:" + userId + " is *", listParams, requestOptions);
+        Tenant[] tenants = Arrays.stream(queryResultSet.getResults()).map(result -> new Tenant(result.getObjectId(), result.getMeta())).toArray(Tenant[]::new);
+        return new ListResult<Tenant>(tenants, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Roles
+    public Role createRole() throws WarrantException {
+        return createRole(new RequestOptions());
+    }
+
+    public Role createRole(RequestOptions requestOptions) throws WarrantException {
+        return createObject(Role.OBJECT_TYPE, Role.class, requestOptions);
+    }
+
     public Role createRole(Role role) throws WarrantException {
         return createRole(role, new RequestOptions());
     }
 
     public Role createRole(Role role, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/roles", role, Role.class, requestOptions.asMap());
+        return createObject(Role.OBJECT_TYPE, role.getRoleId(), role.getMeta(), Role.class, requestOptions);
     }
 
     public Role updateRole(String roleId, Role toUpdate) throws WarrantException {
@@ -243,7 +283,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Role updateRole(String roleId, Role toUpdate, RequestOptions requestOptions) throws WarrantException {
-        return makePutRequest("/v1/roles/" + roleId, toUpdate, Role.class, requestOptions.asMap());
+        return updateObject(Role.OBJECT_TYPE, roleId, toUpdate.getMeta(), Role.class, requestOptions);
     }
 
     public void deleteRole(Role role) throws WarrantException {
@@ -259,7 +299,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deleteRole(String roleId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/roles/" + roleId, requestOptions.asMap());
+        deleteObject(Role.OBJECT_TYPE, roleId, requestOptions);
     }
 
     public Role getRole(String roleId) throws WarrantException {
@@ -267,64 +307,76 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Role getRole(String roleId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/roles/" + roleId, Role.class, requestOptions.asMap());
+        return getObject(Role.OBJECT_TYPE, roleId, Role.class, requestOptions);
     }
 
-    public Role[] listRoles(int limit, int page) throws WarrantException {
-        return listRoles(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Role> listRoles(int limit) throws WarrantException {
+        return listRoles(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Role[] listRoles(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listRoles(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Role> listRoles(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listRoles(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Role[] listRoles(ListParams listParams) throws WarrantException {
+    public ListResult<Role> listRoles(ListParams listParams) throws WarrantException {
         return listRoles(listParams, new RequestOptions());
     }
 
-    public Role[] listRoles(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/roles", listParams.asMap(), Role[].class, requestOptions.asMap());
+    public ListResult<Role> listRoles(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult roleObjects = listObjects(new ObjectFilters().withObjectType(Role.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        Role[] roles = Arrays.stream(roleObjects.getResults()).map(result -> new Role(result.getObjectId(), result.getMeta())).toArray(Role[]::new);
+        return new ListResult<Role>(roles, roleObjects.getPrevCursor(), roleObjects.getNextCursor());
     }
 
-    public Role[] listRolesForUser(User user, int limit, int page) throws WarrantException {
-        return listRolesForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Role> listRolesForUser(User user, int limit) throws WarrantException {
+        return listRolesForUser(user.getUserId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Role[] listRolesForUser(User user, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listRolesForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Role> listRolesForUser(User user, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listRolesForUser(user.getUserId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Role[] listRolesForUser(User user, ListParams listParams) throws WarrantException {
+    public ListResult<Role> listRolesForUser(User user, ListParams listParams) throws WarrantException {
         return listRolesForUser(user.getUserId(), listParams, new RequestOptions());
     }
 
-    public Role[] listRolesForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Role> listRolesForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listRolesForUser(user.getUserId(), listParams, requestOptions);
     }
 
-    public Role[] listRolesForUser(String userId, int limit, int page) throws WarrantException {
-        return listRolesForUser(userId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Role> listRolesForUser(String userId, int limit) throws WarrantException {
+        return listRolesForUser(userId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Role[] listRolesForUser(String userId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listRolesForUser(userId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Role> listRolesForUser(String userId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listRolesForUser(userId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Role[] listRolesForUser(String userId, ListParams listParams) throws WarrantException {
+    public ListResult<Role> listRolesForUser(String userId, ListParams listParams) throws WarrantException {
         return listRolesForUser(userId, listParams, new RequestOptions());
     }
 
-    public Role[] listRolesForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId + "/roles", listParams.asMap(), Role[].class, requestOptions.asMap());
+    public ListResult<Role> listRolesForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select role where user:" + userId + " is *", listParams, requestOptions);
+        Role[] roles = Arrays.stream(queryResultSet.getResults()).map(result -> new Role(result.getObjectId(), result.getMeta())).toArray(Role[]::new);
+        return new ListResult<Role>(roles, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Permissions
+    public Permission createPermission() throws WarrantException {
+        return createPermission(new RequestOptions());
+    }
+
+    public Permission createPermission(RequestOptions requestOptions) throws WarrantException {
+        return createObject(Permission.OBJECT_TYPE, Permission.class, requestOptions);
+    }
+
     public Permission createPermission(Permission permission) throws WarrantException {
         return createPermission(permission, new RequestOptions());
     }
 
     public Permission createPermission(Permission permission, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/permissions", permission, Permission.class, requestOptions.asMap());
+        return createObject(Permission.OBJECT_TYPE, permission.getPermissionId(), permission.getMeta(), Permission.class, requestOptions);
     }
 
     public Permission updatePermission(String permissionId, Permission toUpdate) throws WarrantException {
@@ -332,7 +384,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Permission updatePermission(String permissionId, Permission toUpdate, RequestOptions requestOptions) throws WarrantException {
-        return makePutRequest("/v1/permissions/" + permissionId, toUpdate, Permission.class, requestOptions.asMap());
+        return updateObject(Permission.OBJECT_TYPE, permissionId, toUpdate.getMeta(), Permission.class, requestOptions);
     }
 
     public void deletePermission(Permission permission) throws WarrantException {
@@ -348,7 +400,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deletePermission(String permissionId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/permissions/" + permissionId, requestOptions.asMap());
+        deleteObject(Permission.OBJECT_TYPE, permissionId, requestOptions);
     }
 
     public Permission getPermission(String permissionId) throws WarrantException {
@@ -356,96 +408,110 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Permission getPermission(String permissionId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/permissions/" + permissionId, Permission.class, requestOptions.asMap());
+        return getObject(Permission.OBJECT_TYPE, permissionId, Permission.class, requestOptions);
     }
 
-    public Permission[] listPermissions(int limit, int page) throws WarrantException {
-        return listPermissions(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Permission> listPermissions(int limit) throws WarrantException {
+        return listPermissions(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Permission[] listPermissions(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPermissions(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Permission> listPermissions(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPermissions(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Permission[] listPermissions(ListParams listParams) throws WarrantException {
+    public ListResult<Permission> listPermissions(ListParams listParams) throws WarrantException {
         return listPermissions(listParams, new RequestOptions());
     }
 
-    public Permission[] listPermissions(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/permissions", listParams.asMap(), Permission[].class, requestOptions.asMap());
+    public ListResult<Permission> listPermissions(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult permissionObjects = listObjects(new ObjectFilters().withObjectType(Permission.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        Permission[] permissions = Arrays.stream(permissionObjects.getResults()).map(result -> new Permission(result.getObjectId(), result.getMeta())).toArray(Permission[]::new);
+        return new ListResult<Permission>(permissions, permissionObjects.getPrevCursor(), permissionObjects.getNextCursor());
     }
 
-    public Permission[] listPermissionsForUser(User user, int limit, int page) throws WarrantException {
-        return listPermissionsForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Permission> listPermissionsForUser(User user, int limit) throws WarrantException {
+        return listPermissionsForUser(user.getUserId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Permission[] listPermissionsForUser(User user, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPermissionsForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Permission> listPermissionsForUser(User user, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPermissionsForUser(user.getUserId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Permission[] listPermissionsForUser(User user, ListParams listParams) throws WarrantException {
+    public ListResult<Permission> listPermissionsForUser(User user, ListParams listParams) throws WarrantException {
         return listPermissionsForUser(user.getUserId(), listParams, new RequestOptions());
     }
 
-    public Permission[] listPermissionsForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Permission> listPermissionsForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listPermissionsForUser(user.getUserId(), listParams, requestOptions);
     }
 
-    public Permission[] listPermissionsForUser(String userId, int limit, int page) throws WarrantException {
-        return listPermissionsForUser(userId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Permission> listPermissionsForUser(String userId, int limit) throws WarrantException {
+        return listPermissionsForUser(userId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Permission[] listPermissionsForUser(String userId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPermissionsForUser(userId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Permission> listPermissionsForUser(String userId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPermissionsForUser(userId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Permission[] listPermissionsForUser(String userId, ListParams listParams) throws WarrantException {
+    public ListResult<Permission> listPermissionsForUser(String userId, ListParams listParams) throws WarrantException {
         return listPermissionsForUser(userId, listParams, new RequestOptions());
     }
 
-    public Permission[] listPermissionsForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId + "/permissions", listParams.asMap(), Permission[].class, requestOptions.asMap());
+    public ListResult<Permission> listPermissionsForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select permission where user:" + userId + " is *", listParams, requestOptions);
+        Permission[] permissions = Arrays.stream(queryResultSet.getResults()).map(result -> new Permission(result.getObjectId(), result.getMeta())).toArray(Permission[]::new);
+        return new ListResult<Permission>(permissions, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
-    public Permission[] listPermissionsForRole(Role role, int limit, int page) throws WarrantException {
-        return listPermissionsForRole(role.getRoleId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Permission> listPermissionsForRole(Role role, int limit) throws WarrantException {
+        return listPermissionsForRole(role.getRoleId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Permission[] listPermissionsForRole(Role role, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPermissionsForRole(role.getRoleId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Permission> listPermissionsForRole(Role role, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPermissionsForRole(role.getRoleId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Permission[] listPermissionsForRole(Role role, ListParams listParams) throws WarrantException {
+    public ListResult<Permission> listPermissionsForRole(Role role, ListParams listParams) throws WarrantException {
         return listPermissionsForRole(role.getRoleId(), listParams, new RequestOptions());
     }
 
-    public Permission[] listPermissionsForRole(Role role, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Permission> listPermissionsForRole(Role role, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listPermissionsForRole(role.getRoleId(), listParams, requestOptions);
     }
 
-    public Permission[] listPermissionsForRole(String roleId, int limit, int page) throws WarrantException {
-        return listPermissionsForRole(roleId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Permission> listPermissionsForRole(String roleId, int limit) throws WarrantException {
+        return listPermissionsForRole(roleId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Permission[] listPermissionsForRole(String roleId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPermissionsForRole(roleId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Permission> listPermissionsForRole(String roleId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPermissionsForRole(roleId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Permission[] listPermissionsForRole(String roleId, ListParams listParams) throws WarrantException {
+    public ListResult<Permission> listPermissionsForRole(String roleId, ListParams listParams) throws WarrantException {
         return listPermissionsForRole(roleId, listParams, new RequestOptions());
     }
 
-    public Permission[] listPermissionsForRole(String roleId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/roles/" + roleId + "/permissions", listParams.asMap(), Permission[].class, requestOptions.asMap());
+    public ListResult<Permission> listPermissionsForRole(String roleId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select permission where role:" + roleId + " is *", listParams, requestOptions);
+        Permission[] permissions = Arrays.stream(queryResultSet.getResults()).map(result -> new Permission(result.getObjectId(), result.getMeta())).toArray(Permission[]::new);
+        return new ListResult<Permission>(permissions, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Features
+    public Feature createFeature() throws WarrantException {
+        return createFeature(new RequestOptions());
+    }
+
+    public Feature createFeature(RequestOptions requestOptions) throws WarrantException {
+        return createObject(Feature.OBJECT_TYPE, Feature.class, requestOptions);
+    }
+
     public Feature createFeature(Feature feature) throws WarrantException {
         return createFeature(feature, new RequestOptions());
     }
 
     public Feature createFeature(Feature feature, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/features", feature, Feature.class, requestOptions.asMap());
+        return createObject(Feature.OBJECT_TYPE, feature.getFeatureId(), feature.getMeta(), Feature.class, requestOptions);
     }
 
     public void deleteFeature(Feature feature) throws WarrantException {
@@ -461,7 +527,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deleteFeature(String featureId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/features/" + featureId, requestOptions.asMap());
+        deleteObject(Feature.OBJECT_TYPE, featureId, requestOptions);
     }
 
     public Feature getFeature(String featureId) throws WarrantException {
@@ -469,128 +535,144 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public Feature getFeature(String featureId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/features/" + featureId, Feature.class, requestOptions.asMap());
+        return getObject(Feature.OBJECT_TYPE, featureId, Feature.class, requestOptions);
     }
 
-    public Feature[] listFeatures(int limit, int page) throws WarrantException {
-        return listFeatures(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeatures(int limit) throws WarrantException {
+        return listFeatures(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeatures(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeatures(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeatures(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeatures(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeatures(ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeatures(ListParams listParams) throws WarrantException {
         return listFeatures(listParams, new RequestOptions());
     }
 
-    public Feature[] listFeatures(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/features", listParams.asMap(), Feature[].class, requestOptions.asMap());
+    public ListResult<Feature> listFeatures(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult featureObjects = listObjects(new ObjectFilters().withObjectType(Feature.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        Feature[] features = Arrays.stream(featureObjects.getResults()).map(result -> new Feature(result.getObjectId(), result.getMeta())).toArray(Feature[]::new);
+        return new ListResult<Feature>(features, featureObjects.getPrevCursor(), featureObjects.getNextCursor());
     }
 
-    public Feature[] listFeaturesForUser(User user, int limit, int page) throws WarrantException {
-        return listFeaturesForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForUser(User user, int limit) throws WarrantException {
+        return listFeaturesForUser(user.getUserId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForUser(User user, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForUser(User user, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForUser(user.getUserId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForUser(User user, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForUser(User user, ListParams listParams) throws WarrantException {
         return listFeaturesForUser(user.getUserId(), listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Feature> listFeaturesForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listFeaturesForUser(user.getUserId(), listParams, requestOptions);
     }
 
-    public Feature[] listFeaturesForUser(String userId, int limit, int page) throws WarrantException {
-        return listFeaturesForUser(userId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForUser(String userId, int limit) throws WarrantException {
+        return listFeaturesForUser(userId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForUser(String userId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForUser(userId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForUser(String userId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForUser(userId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForUser(String userId, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForUser(String userId, ListParams listParams) throws WarrantException {
         return listFeaturesForUser(userId, listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId + "/features", listParams.asMap(), Feature[].class, requestOptions.asMap());
+    public ListResult<Feature> listFeaturesForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select feature where user:" + userId + " is *", listParams, requestOptions);
+        Feature[] features = Arrays.stream(queryResultSet.getResults()).map(result -> new Feature(result.getObjectId(), result.getMeta())).toArray(Feature[]::new);
+        return new ListResult<Feature>(features, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
-    public Feature[] listFeaturesForTenant(Tenant tenant, int limit, int page) throws WarrantException {
-        return listFeaturesForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForTenant(Tenant tenant, int limit) throws WarrantException {
+        return listFeaturesForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForTenant(Tenant tenant, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForTenant(Tenant tenant, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
         return listFeaturesForTenant(tenant.getTenantId(), listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Feature> listFeaturesForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listFeaturesForTenant(tenant.getTenantId(), listParams, requestOptions);
     }
 
-    public Feature[] listFeaturesForTenant(String tenantId, int limit, int page) throws WarrantException {
-        return listFeaturesForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForTenant(String tenantId, int limit) throws WarrantException {
+        return listFeaturesForTenant(tenantId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForTenant(String tenantId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForTenant(String tenantId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForTenant(tenantId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForTenant(String tenantId, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForTenant(String tenantId, ListParams listParams) throws WarrantException {
         return listFeaturesForTenant(tenantId, listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/tenants/" + tenantId + "/features", listParams.asMap(), Feature[].class, requestOptions.asMap());
+    public ListResult<Feature> listFeaturesForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select feature where tenant:" + tenantId + " is *", listParams, requestOptions);
+        Feature[] features = Arrays.stream(queryResultSet.getResults()).map(result -> new Feature(result.getObjectId(), result.getMeta())).toArray(Feature[]::new);
+        return new ListResult<Feature>(features, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
-    public Feature[] listFeaturesForPricingTier(PricingTier pricingTier, int limit, int page) throws WarrantException {
-        return listFeaturesForPricingTier(pricingTier.getPricingTierId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForPricingTier(PricingTier pricingTier, int limit) throws WarrantException {
+        return listFeaturesForPricingTier(pricingTier.getPricingTierId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForPricingTier(PricingTier pricingTier, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForPricingTier(pricingTier.getPricingTierId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForPricingTier(PricingTier pricingTier, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForPricingTier(pricingTier.getPricingTierId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForPricingTier(PricingTier pricingTier, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForPricingTier(PricingTier pricingTier, ListParams listParams) throws WarrantException {
         return listFeaturesForPricingTier(pricingTier.getPricingTierId(), listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForPricingTier(PricingTier pricingTier, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<Feature> listFeaturesForPricingTier(PricingTier pricingTier, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listFeaturesForPricingTier(pricingTier.getPricingTierId(), listParams, requestOptions);
     }
 
-    public Feature[] listFeaturesForPricingTier(String pricingTierId, int limit, int page) throws WarrantException {
-        return listFeaturesForPricingTier(pricingTierId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<Feature> listFeaturesForPricingTier(String pricingTierId, int limit) throws WarrantException {
+        return listFeaturesForPricingTier(pricingTierId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public Feature[] listFeaturesForPricingTier(String pricingTierId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listFeaturesForPricingTier(pricingTierId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<Feature> listFeaturesForPricingTier(String pricingTierId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listFeaturesForPricingTier(pricingTierId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public Feature[] listFeaturesForPricingTier(String pricingTierId, ListParams listParams) throws WarrantException {
+    public ListResult<Feature> listFeaturesForPricingTier(String pricingTierId, ListParams listParams) throws WarrantException {
         return listFeaturesForPricingTier(pricingTierId, listParams, new RequestOptions());
     }
 
-    public Feature[] listFeaturesForPricingTier(String pricingTierId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/pricing-tiers/" + pricingTierId + "/features", listParams.asMap(), Feature[].class, requestOptions.asMap());
+    public ListResult<Feature> listFeaturesForPricingTier(String pricingTierId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select feature where pricing-tier:" + pricingTierId + " is *", listParams, requestOptions);
+        Feature[] features = Arrays.stream(queryResultSet.getResults()).map(result -> new Feature(result.getObjectId(), result.getMeta())).toArray(Feature[]::new);
+        return new ListResult<Feature>(features, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Pricing Tiers
+    public PricingTier createPricingTier() throws WarrantException {
+        return createPricingTier(new RequestOptions());
+    }
+
+    public PricingTier createPricingTier(RequestOptions requestOptions) throws WarrantException {
+        return createObject(PricingTier.OBJECT_TYPE, PricingTier.class, requestOptions);
+    }
+
     public PricingTier createPricingTier(PricingTier pricingTier) throws WarrantException {
         return createPricingTier(pricingTier, new RequestOptions());
     }
 
     public PricingTier createPricingTier(PricingTier pricingTier, RequestOptions requestOptions) throws WarrantException {
-        return makePostRequest("/v1/pricing-tiers", pricingTier, PricingTier.class, requestOptions.asMap());
+        return createObject(PricingTier.OBJECT_TYPE, pricingTier.getPricingTierId(), pricingTier.getMeta(), PricingTier.class, requestOptions);
     }
 
     public void deletePricingTier(PricingTier pricingTier) throws WarrantException {
@@ -606,7 +688,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public void deletePricingTier(String pricingTierId, RequestOptions requestOptions) throws WarrantException {
-        makeDeleteRequest("/v1/pricing-tiers/" + pricingTierId, requestOptions.asMap());
+        deleteObject(PricingTier.OBJECT_TYPE, pricingTierId, requestOptions);
     }
 
     public PricingTier getPricingTier(String pricingTierId) throws WarrantException {
@@ -614,87 +696,93 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public PricingTier getPricingTier(String pricingTierId, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/pricing-tiers/" + pricingTierId, PricingTier.class, requestOptions.asMap());
+        return getObject(PricingTier.OBJECT_TYPE, pricingTierId, PricingTier.class, requestOptions);
     }
 
-    public PricingTier[] listPricingTiers(int limit, int page) throws WarrantException {
-        return listPricingTiers(new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<PricingTier> listPricingTiers(int limit) throws WarrantException {
+        return listPricingTiers(new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiers(int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPricingTiers(new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<PricingTier> listPricingTiers(int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPricingTiers(new ListParams().withLimit(limit), requestOptions);
     }
 
-    public PricingTier[] listPricingTiers(ListParams listParams) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiers(ListParams listParams) throws WarrantException {
         return listPricingTiers(listParams, new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/pricing-tiers", listParams.asMap(), PricingTier[].class, requestOptions.asMap());
+    public ListResult<PricingTier> listPricingTiers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        BaseListResult pricingTierObjects = listObjects(new ObjectFilters().withObjectType(PricingTier.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        PricingTier[] pricingTiers = Arrays.stream(pricingTierObjects.getResults()).map(result -> new PricingTier(result.getObjectId(), result.getMeta())).toArray(PricingTier[]::new);
+        return new ListResult<PricingTier>(pricingTiers, pricingTierObjects.getPrevCursor(), pricingTierObjects.getNextCursor());
     }
 
-    public PricingTier[] listPricingTiersForTenant(Tenant tenant, int limit, int page) throws WarrantException {
-        return listPricingTiersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<PricingTier> listPricingTiersForTenant(Tenant tenant, int limit) throws WarrantException {
+        return listPricingTiersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForTenant(Tenant tenant, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPricingTiersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<PricingTier> listPricingTiersForTenant(Tenant tenant, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPricingTiersForTenant(tenant.getTenantId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForTenant(Tenant tenant, ListParams listParams) throws WarrantException {
         return listPricingTiersForTenant(tenant.getTenantId(), listParams, new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForTenant(Tenant tenant, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listPricingTiersForTenant(tenant.getTenantId(), listParams, requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForTenant(String tenantId, int limit, int page) throws WarrantException {
-        return listPricingTiersForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<PricingTier> listPricingTiersForTenant(String tenantId, int limit) throws WarrantException {
+        return listPricingTiersForTenant(tenantId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForTenant(String tenantId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPricingTiersForTenant(tenantId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<PricingTier> listPricingTiersForTenant(String tenantId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPricingTiersForTenant(tenantId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForTenant(String tenantId, ListParams listParams) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForTenant(String tenantId, ListParams listParams) throws WarrantException {
         return listPricingTiersForTenant(tenantId, listParams, new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/tenants/" + tenantId + "/pricing-tiers", listParams.asMap(), PricingTier[].class, requestOptions.asMap());
+    public ListResult<PricingTier> listPricingTiersForTenant(String tenantId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select pricing-tier where tenant:" + tenantId + " is *", listParams, requestOptions);
+        PricingTier[] pricingTiers = Arrays.stream(queryResultSet.getResults()).map(result -> new PricingTier(result.getObjectId(), result.getMeta())).toArray(PricingTier[]::new);
+        return new ListResult<PricingTier>(pricingTiers, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
-    public PricingTier[] listPricingTiersForUser(User user, int limit, int page) throws WarrantException {
-        return listPricingTiersForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<PricingTier> listPricingTiersForUser(User user, int limit) throws WarrantException {
+        return listPricingTiersForUser(user.getUserId(), new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForUser(User user, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPricingTiersForUser(user.getUserId(), new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<PricingTier> listPricingTiersForUser(User user, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPricingTiersForUser(user.getUserId(), new ListParams().withLimit(limit), requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForUser(User user, ListParams listParams) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForUser(User user, ListParams listParams) throws WarrantException {
         return listPricingTiersForUser(user.getUserId(), listParams, new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForUser(User user, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
         return listPricingTiersForUser(user.getUserId(), listParams, requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForUser(String userId, int limit, int page) throws WarrantException {
-        return listPricingTiersForUser(userId, new ListParams().withLimit(limit).withPage(page), new RequestOptions());
+    public ListResult<PricingTier> listPricingTiersForUser(String userId, int limit) throws WarrantException {
+        return listPricingTiersForUser(userId, new ListParams().withLimit(limit), new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForUser(String userId, int limit, int page, RequestOptions requestOptions) throws WarrantException {
-        return listPricingTiersForUser(userId, new ListParams().withLimit(limit).withPage(page), requestOptions);
+    public ListResult<PricingTier> listPricingTiersForUser(String userId, int limit, RequestOptions requestOptions) throws WarrantException {
+        return listPricingTiersForUser(userId, new ListParams().withLimit(limit), requestOptions);
     }
 
-    public PricingTier[] listPricingTiersForUser(String userId, ListParams listParams) throws WarrantException {
+    public ListResult<PricingTier> listPricingTiersForUser(String userId, ListParams listParams) throws WarrantException {
         return listPricingTiersForUser(userId, listParams, new RequestOptions());
     }
 
-    public PricingTier[] listPricingTiersForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        return makeGetRequest("/v1/users/" + userId + "/pricing-tiers", listParams.asMap(), PricingTier[].class, requestOptions.asMap());
+    public ListResult<PricingTier> listPricingTiersForUser(String userId, ListParams listParams, RequestOptions requestOptions) throws WarrantException {
+        QueryResultSet queryResultSet = query("select pricing-tier where user:" + userId + " is *", listParams, requestOptions);
+        PricingTier[] pricingTiers = Arrays.stream(queryResultSet.getResults()).map(result -> new PricingTier(result.getObjectId(), result.getMeta())).toArray(PricingTier[]::new);
+        return new ListResult<PricingTier>(pricingTiers, queryResultSet.getPrevCursor(), queryResultSet.getNextCursor());
     }
 
     // Assign

--- a/src/main/java/dev/warrant/WarrantClient.java
+++ b/src/main/java/dev/warrant/WarrantClient.java
@@ -10,7 +10,7 @@ import dev.warrant.exception.WarrantException;
 import dev.warrant.model.WarrantSubject;
 import dev.warrant.model.object.BaseWarrantObject;
 import dev.warrant.model.object.Feature;
-import dev.warrant.model.object.BaseListResult;
+import dev.warrant.model.object.BaseWarrantObjectListResult;
 import dev.warrant.model.object.ListResult;
 import dev.warrant.model.object.Permission;
 import dev.warrant.model.object.PricingTier;
@@ -105,7 +105,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<User> listUsers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult userObjects = listObjects(new ObjectFilters().withObjectType(User.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult userObjects = listObjects(new ObjectFilters().withObjectType(User.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         User[] users = Arrays.stream(userObjects.getResults()).map(result -> new User(result.getObjectId(), result.getMeta())).toArray(User[]::new);
         return new ListResult<User>(users, userObjects.getPrevCursor(), userObjects.getNextCursor());
     }
@@ -222,7 +222,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<Tenant> listTenants(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult tenantObjects = listObjects(new ObjectFilters().withObjectType(Tenant.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult tenantObjects = listObjects(new ObjectFilters().withObjectType(Tenant.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         Tenant[] tenants = Arrays.stream(tenantObjects.getResults()).map(result -> new Tenant(result.getObjectId(), result.getMeta())).toArray(Tenant[]::new);
         return new ListResult<Tenant>(tenants, tenantObjects.getPrevCursor(), tenantObjects.getNextCursor());
     }
@@ -323,7 +323,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<Role> listRoles(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult roleObjects = listObjects(new ObjectFilters().withObjectType(Role.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult roleObjects = listObjects(new ObjectFilters().withObjectType(Role.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         Role[] roles = Arrays.stream(roleObjects.getResults()).map(result -> new Role(result.getObjectId(), result.getMeta())).toArray(Role[]::new);
         return new ListResult<Role>(roles, roleObjects.getPrevCursor(), roleObjects.getNextCursor());
     }
@@ -424,7 +424,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<Permission> listPermissions(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult permissionObjects = listObjects(new ObjectFilters().withObjectType(Permission.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult permissionObjects = listObjects(new ObjectFilters().withObjectType(Permission.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         Permission[] permissions = Arrays.stream(permissionObjects.getResults()).map(result -> new Permission(result.getObjectId(), result.getMeta())).toArray(Permission[]::new);
         return new ListResult<Permission>(permissions, permissionObjects.getPrevCursor(), permissionObjects.getNextCursor());
     }
@@ -551,7 +551,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<Feature> listFeatures(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult featureObjects = listObjects(new ObjectFilters().withObjectType(Feature.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult featureObjects = listObjects(new ObjectFilters().withObjectType(Feature.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         Feature[] features = Arrays.stream(featureObjects.getResults()).map(result -> new Feature(result.getObjectId(), result.getMeta())).toArray(Feature[]::new);
         return new ListResult<Feature>(features, featureObjects.getPrevCursor(), featureObjects.getNextCursor());
     }
@@ -712,7 +712,7 @@ public class WarrantClient extends WarrantBaseClient {
     }
 
     public ListResult<PricingTier> listPricingTiers(ListParams listParams, RequestOptions requestOptions) throws WarrantException {
-        BaseListResult pricingTierObjects = listObjects(new ObjectFilters().withObjectType(PricingTier.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
+        BaseWarrantObjectListResult pricingTierObjects = listObjects(new ObjectFilters().withObjectType(PricingTier.OBJECT_TYPE), new ListParams().withLimit(10), requestOptions);
         PricingTier[] pricingTiers = Arrays.stream(pricingTierObjects.getResults()).map(result -> new PricingTier(result.getObjectId(), result.getMeta())).toArray(PricingTier[]::new);
         return new ListResult<PricingTier>(pricingTiers, pricingTierObjects.getPrevCursor(), pricingTierObjects.getNextCursor());
     }

--- a/src/main/java/dev/warrant/WarrantClient.java
+++ b/src/main/java/dev/warrant/WarrantClient.java
@@ -64,24 +64,24 @@ public class WarrantClient extends WarrantBaseClient {
         return updateObject(User.OBJECT_TYPE, userId, toUpdate.getMeta(), User.class, requestOptions);
     }
 
-    public void deleteUser(User user) throws WarrantException {
-        deleteUser(user.getUserId(), new RequestOptions());
+    public String deleteUser(User user) throws WarrantException {
+        return deleteUser(user.getUserId(), new RequestOptions());
     }
 
-    public void deleteUser(String userId) throws WarrantException {
-        deleteUser(userId, new RequestOptions());
+    public String deleteUser(String userId) throws WarrantException {
+        return deleteUser(userId, new RequestOptions());
     }
 
-    public void deleteUser(String userId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(User.OBJECT_TYPE, userId, requestOptions);
+    public String deleteUser(String userId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(User.OBJECT_TYPE, userId, requestOptions);
     }
 
-    public void deleteUsers(User[] users) throws WarrantException {
-        deleteObjects(users);
+    public String deleteUsers(User[] users) throws WarrantException {
+        return deleteObjects(users);
     }
 
-    public void deleteUsers(User[] users, RequestOptions requestOptions) throws WarrantException {
-        deleteObjects(users, requestOptions);
+    public String deleteUsers(User[] users, RequestOptions requestOptions) throws WarrantException {
+        return deleteObjects(users, requestOptions);
     }
 
     public User getUser(String userId) throws WarrantException {
@@ -177,28 +177,28 @@ public class WarrantClient extends WarrantBaseClient {
         return updateObject(Tenant.OBJECT_TYPE, tenantId, toUpdate.getMeta(), Tenant.class, requestOptions);
     }
 
-    public void deleteTenant(Tenant tenant) throws WarrantException {
-        deleteTenant(tenant.getTenantId(), new RequestOptions());
+    public String deleteTenant(Tenant tenant) throws WarrantException {
+        return deleteTenant(tenant.getTenantId(), new RequestOptions());
     }
 
-    public void deleteTenant(Tenant tenant, RequestOptions requestOptions) throws WarrantException {
-        deleteTenant(tenant.getTenantId(), requestOptions);
+    public String deleteTenant(Tenant tenant, RequestOptions requestOptions) throws WarrantException {
+        return deleteTenant(tenant.getTenantId(), requestOptions);
     }
 
-    public void deleteTenant(String tenantId) throws WarrantException {
-        deleteTenant(tenantId, new RequestOptions());
+    public String deleteTenant(String tenantId) throws WarrantException {
+        return deleteTenant(tenantId, new RequestOptions());
     }
 
-    public void deleteTenant(String tenantId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(Tenant.OBJECT_TYPE, tenantId, requestOptions);
+    public String deleteTenant(String tenantId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(Tenant.OBJECT_TYPE, tenantId, requestOptions);
     }
 
-    public void deleteTenants(Tenant[] tenants) throws WarrantException {
-        deleteObjects(tenants);
+    public String deleteTenants(Tenant[] tenants) throws WarrantException {
+        return deleteTenants(tenants, new RequestOptions());
     }
 
-    public void deleteTenants(Tenant[] tenants, RequestOptions requestOptions) throws WarrantException {
-        deleteObjects(tenants, requestOptions);
+    public String deleteTenants(Tenant[] tenants, RequestOptions requestOptions) throws WarrantException {
+        return deleteObjects(tenants, requestOptions);
     }
 
     public Tenant getTenant(String tenantId) throws WarrantException {
@@ -286,20 +286,20 @@ public class WarrantClient extends WarrantBaseClient {
         return updateObject(Role.OBJECT_TYPE, roleId, toUpdate.getMeta(), Role.class, requestOptions);
     }
 
-    public void deleteRole(Role role) throws WarrantException {
-        deleteRole(role.getRoleId(), new RequestOptions());
+    public String deleteRole(Role role) throws WarrantException {
+        return deleteRole(role.getRoleId(), new RequestOptions());
     }
 
-    public void deleteRole(Role role, RequestOptions requestOptions) throws WarrantException {
-        deleteRole(role.getRoleId(), requestOptions);
+    public String deleteRole(Role role, RequestOptions requestOptions) throws WarrantException {
+        return deleteRole(role.getRoleId(), requestOptions);
     }
 
-    public void deleteRole(String roleId) throws WarrantException {
-        deleteRole(roleId, new RequestOptions());
+    public String deleteRole(String roleId) throws WarrantException {
+        return deleteRole(roleId, new RequestOptions());
     }
 
-    public void deleteRole(String roleId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(Role.OBJECT_TYPE, roleId, requestOptions);
+    public String deleteRole(String roleId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(Role.OBJECT_TYPE, roleId, requestOptions);
     }
 
     public Role getRole(String roleId) throws WarrantException {
@@ -387,20 +387,20 @@ public class WarrantClient extends WarrantBaseClient {
         return updateObject(Permission.OBJECT_TYPE, permissionId, toUpdate.getMeta(), Permission.class, requestOptions);
     }
 
-    public void deletePermission(Permission permission) throws WarrantException {
-        deletePermission(permission.getPermissionId(), new RequestOptions());
+    public String deletePermission(Permission permission) throws WarrantException {
+        return deletePermission(permission.getPermissionId(), new RequestOptions());
     }
 
-    public void deletePermission(Permission permission, RequestOptions requestOptions) throws WarrantException {
-        deletePermission(permission.getPermissionId(), requestOptions);
+    public String deletePermission(Permission permission, RequestOptions requestOptions) throws WarrantException {
+        return deletePermission(permission.getPermissionId(), requestOptions);
     }
 
-    public void deletePermission(String permissionId) throws WarrantException {
-        deletePermission(permissionId, new RequestOptions());
+    public String deletePermission(String permissionId) throws WarrantException {
+        return deletePermission(permissionId, new RequestOptions());
     }
 
-    public void deletePermission(String permissionId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(Permission.OBJECT_TYPE, permissionId, requestOptions);
+    public String deletePermission(String permissionId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(Permission.OBJECT_TYPE, permissionId, requestOptions);
     }
 
     public Permission getPermission(String permissionId) throws WarrantException {
@@ -514,20 +514,20 @@ public class WarrantClient extends WarrantBaseClient {
         return createObject(Feature.OBJECT_TYPE, feature.getFeatureId(), feature.getMeta(), Feature.class, requestOptions);
     }
 
-    public void deleteFeature(Feature feature) throws WarrantException {
-        deleteFeature(feature.getFeatureId(), new RequestOptions());
+    public String deleteFeature(Feature feature) throws WarrantException {
+        return deleteFeature(feature.getFeatureId(), new RequestOptions());
     }
 
-    public void deleteFeature(Feature feature, RequestOptions requestOptions) throws WarrantException {
-        deleteFeature(feature.getFeatureId(), requestOptions);
+    public String deleteFeature(Feature feature, RequestOptions requestOptions) throws WarrantException {
+        return deleteFeature(feature.getFeatureId(), requestOptions);
     }
 
-    public void deleteFeature(String featureId) throws WarrantException {
-        deleteFeature(featureId, new RequestOptions());
+    public String deleteFeature(String featureId) throws WarrantException {
+        return deleteFeature(featureId, new RequestOptions());
     }
 
-    public void deleteFeature(String featureId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(Feature.OBJECT_TYPE, featureId, requestOptions);
+    public String deleteFeature(String featureId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(Feature.OBJECT_TYPE, featureId, requestOptions);
     }
 
     public Feature getFeature(String featureId) throws WarrantException {
@@ -675,20 +675,20 @@ public class WarrantClient extends WarrantBaseClient {
         return createObject(PricingTier.OBJECT_TYPE, pricingTier.getPricingTierId(), pricingTier.getMeta(), PricingTier.class, requestOptions);
     }
 
-    public void deletePricingTier(PricingTier pricingTier) throws WarrantException {
-        deletePricingTier(pricingTier.getPricingTierId(), new RequestOptions());
+    public String deletePricingTier(PricingTier pricingTier) throws WarrantException {
+        return deletePricingTier(pricingTier.getPricingTierId(), new RequestOptions());
     }
 
-    public void deletePricingTier(PricingTier pricingTier, RequestOptions requestOptions) throws WarrantException {
-        deletePricingTier(pricingTier.getPricingTierId(), requestOptions);
+    public String deletePricingTier(PricingTier pricingTier, RequestOptions requestOptions) throws WarrantException {
+        return deletePricingTier(pricingTier.getPricingTierId(), requestOptions);
     }
 
-    public void deletePricingTier(String pricingTierId) throws WarrantException {
-        deletePricingTier(pricingTierId, new RequestOptions());
+    public String deletePricingTier(String pricingTierId) throws WarrantException {
+        return deletePricingTier(pricingTierId, new RequestOptions());
     }
 
-    public void deletePricingTier(String pricingTierId, RequestOptions requestOptions) throws WarrantException {
-        deleteObject(PricingTier.OBJECT_TYPE, pricingTierId, requestOptions);
+    public String deletePricingTier(String pricingTierId, RequestOptions requestOptions) throws WarrantException {
+        return deleteObject(PricingTier.OBJECT_TYPE, pricingTierId, requestOptions);
     }
 
     public PricingTier getPricingTier(String pricingTierId) throws WarrantException {

--- a/src/main/java/dev/warrant/model/QueryResult.java
+++ b/src/main/java/dev/warrant/model/QueryResult.java
@@ -1,11 +1,15 @@
 package dev.warrant.model;
 
+import java.util.Map;
+import java.util.HashMap;
+
 public class QueryResult {
 
     private String objectType;
     private String objectId;
     private Warrant warrant;
     private Boolean isImplicit;
+    private Map<String, Object> meta;
 
     public QueryResult() {
         // For json serialization
@@ -16,6 +20,15 @@ public class QueryResult {
         this.objectId = objectId;
         this.warrant = warrant;
         this.isImplicit = isImplicit;
+        this.meta = new HashMap<String, Object>();
+    }
+
+    public QueryResult(String objectType, String objectId, Warrant warrant, Boolean isImplicit, Map<String, Object> meta) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.warrant = warrant;
+        this.isImplicit = isImplicit;
+        this.meta = meta;
     }
 
     public String getObjectType() {
@@ -48,5 +61,13 @@ public class QueryResult {
 
     public void setIsImplicit(Boolean isImplicit) {
         this.isImplicit = isImplicit;
+    }
+
+    public Map<String, Object> getMeta() {
+        return this.meta;
+    }
+
+    public void setMeta(Map<String, Object> meta) {
+        this.meta = meta;
     }
 }

--- a/src/main/java/dev/warrant/model/Warrant.java
+++ b/src/main/java/dev/warrant/model/Warrant.java
@@ -7,6 +7,7 @@ public class Warrant {
     private String relation;
     private WarrantSubject subject;
     private String policy;
+    private String warrantToken;
 
     public Warrant() {
         // For json serialization
@@ -65,5 +66,9 @@ public class Warrant {
 
     public void setPolicy(String policy) {
         this.policy = policy;
+    }
+
+    public String getWarrantToken() {
+        return warrantToken;
     }
 }

--- a/src/main/java/dev/warrant/model/object/BaseListResult.java
+++ b/src/main/java/dev/warrant/model/object/BaseListResult.java
@@ -1,27 +1,30 @@
-package dev.warrant.model;
+package dev.warrant.model.object;
 
-public class QueryResultSet {
-
-    private QueryResult[] results;
+public class BaseListResult {
+    private BaseWarrantObject[] results;
     private String prevCursor;
     private String nextCursor;
 
-    public QueryResultSet() {
+    public BaseListResult() {
         // For json serialization
     }
 
-    public QueryResultSet(QueryResult[] results) {
+    public BaseListResult(BaseWarrantObject[] results) {
         this.results = results;
     }
 
-    public QueryResultSet(QueryResult[] results, String prevCursor, String nextCursor) {
+    public BaseListResult(BaseWarrantObject[] results, String prevCursor, String nextCursor) {
         this.results = results;
         this.prevCursor = prevCursor;
         this.nextCursor = nextCursor;
     }
 
-    public QueryResult[] getResults() {
-        return this.results;
+    public BaseWarrantObject[] getResults() {
+        return results;
+    }
+
+    public void setResults(BaseWarrantObject[] results) {
+        this.results = results;
     }
 
     public String getPrevCursor() {

--- a/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
+++ b/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
@@ -1,0 +1,62 @@
+package dev.warrant.model.object;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class BaseWarrantObject implements WarrantObject {
+    protected String objectType;
+    protected String objectId;
+    protected Map<String, Object> meta;
+
+    public BaseWarrantObject() {
+        // For json serialization
+    }
+
+    public BaseWarrantObject(String objectType, String objectId) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.meta = new HashMap<String, Object>();
+    }
+
+    public BaseWarrantObject(String objectType, String objectId, Map<String, Object> meta) {
+        this.objectType = objectType;
+        this.objectId = objectId;
+        this.meta = meta;
+    }
+
+    public String getObjectType() {
+        return objectType;
+    }
+
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Map<String, Object> meta) {
+        this.meta = meta;
+    }
+
+    public String id() {
+        return objectId;
+    }
+
+    public String type() {
+        return objectType;
+    }
+
+    public Map<String, Object> meta() {
+        return meta;
+    }
+}

--- a/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
+++ b/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
@@ -12,6 +12,11 @@ public class BaseWarrantObject implements WarrantObject {
         // For json serialization
     }
 
+    public BaseWarrantObject(String objectType) {
+        this.objectType = objectType;
+        this.meta = new HashMap<String, Object>();
+    }
+
     public BaseWarrantObject(String objectType, String objectId) {
         this.objectType = objectType;
         this.objectId = objectId;

--- a/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
+++ b/src/main/java/dev/warrant/model/object/BaseWarrantObject.java
@@ -3,6 +3,9 @@ package dev.warrant.model.object;
 import java.util.Map;
 import java.util.HashMap;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class BaseWarrantObject implements WarrantObject {
     protected String objectType;
     protected String objectId;

--- a/src/main/java/dev/warrant/model/object/BaseWarrantObjectListResult.java
+++ b/src/main/java/dev/warrant/model/object/BaseWarrantObjectListResult.java
@@ -1,19 +1,19 @@
 package dev.warrant.model.object;
 
-public class BaseListResult {
+public class BaseWarrantObjectListResult {
     private BaseWarrantObject[] results;
     private String prevCursor;
     private String nextCursor;
 
-    public BaseListResult() {
+    public BaseWarrantObjectListResult() {
         // For json serialization
     }
 
-    public BaseListResult(BaseWarrantObject[] results) {
+    public BaseWarrantObjectListResult(BaseWarrantObject[] results) {
         this.results = results;
     }
 
-    public BaseListResult(BaseWarrantObject[] results, String prevCursor, String nextCursor) {
+    public BaseWarrantObjectListResult(BaseWarrantObject[] results, String prevCursor, String nextCursor) {
         this.results = results;
         this.prevCursor = prevCursor;
         this.nextCursor = nextCursor;

--- a/src/main/java/dev/warrant/model/object/Feature.java
+++ b/src/main/java/dev/warrant/model/object/Feature.java
@@ -1,34 +1,39 @@
 package dev.warrant.model.object;
 
-public class Feature implements WarrantObject {
-    static final String OBJECT_TYPE = "feature";
+import java.util.Map;
 
-    private String featureId;
+public class Feature extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "feature";
 
     public Feature() {
         // For json serialization
+        super();
     }
 
     public Feature(String featureId) {
-        this.featureId = featureId;
+        super(OBJECT_TYPE, featureId);
+    }
+
+    public Feature(String featureId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, featureId, meta);
     }
 
     public String getFeatureId() {
-        return featureId;
+        return objectId;
     }
 
     public void setFeatureId(String featureId) {
-        this.featureId = featureId;
+        this.objectId = featureId;
     }
 
     @Override
     public String id() {
-        return featureId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "feature";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/Feature.java
+++ b/src/main/java/dev/warrant/model/object/Feature.java
@@ -35,9 +35,4 @@ public class Feature extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/ListResult.java
+++ b/src/main/java/dev/warrant/model/object/ListResult.java
@@ -1,6 +1,6 @@
 package dev.warrant.model.object;
 
-public class ListResult<T extends WarrantObject> {
+public class ListResult<T> {
     private T[] results;
     private String prevCursor;
     private String nextCursor;

--- a/src/main/java/dev/warrant/model/object/ListResult.java
+++ b/src/main/java/dev/warrant/model/object/ListResult.java
@@ -1,27 +1,30 @@
-package dev.warrant.model;
+package dev.warrant.model.object;
 
-public class QueryResultSet {
-
-    private QueryResult[] results;
+public class ListResult<T extends WarrantObject> {
+    private T[] results;
     private String prevCursor;
     private String nextCursor;
 
-    public QueryResultSet() {
+    public ListResult() {
         // For json serialization
     }
 
-    public QueryResultSet(QueryResult[] results) {
+    public ListResult(T[] results) {
         this.results = results;
     }
 
-    public QueryResultSet(QueryResult[] results, String prevCursor, String nextCursor) {
+    public ListResult(T[] results, String prevCursor, String nextCursor) {
         this.results = results;
         this.prevCursor = prevCursor;
         this.nextCursor = nextCursor;
     }
 
-    public QueryResult[] getResults() {
-        return this.results;
+    public T[] getResults() {
+        return results;
+    }
+
+    public void setResults(T[] results) {
+        this.results = results;
     }
 
     public String getPrevCursor() {

--- a/src/main/java/dev/warrant/model/object/Permission.java
+++ b/src/main/java/dev/warrant/model/object/Permission.java
@@ -1,58 +1,79 @@
 package dev.warrant.model.object;
 
-public class Permission implements WarrantObject {
-    public static final String OBJECT_TYPE = "permission";
+import java.util.Map;
 
-    private String permissionId;
-    private String name;
-    private String description;
+public class Permission extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "permission";
+    static final String NAME_KEY = "name";
+    static final String DESCRIPTION_KEY = "description";
 
     public Permission() {
         // For json serialization
+        super();
     }
 
     public Permission(String permissionId) {
-        this.permissionId = permissionId;
+        super(OBJECT_TYPE, permissionId);
     }
 
     public Permission(String permissionId, String name, String description) {
-        this.permissionId = permissionId;
-        this.name = name;
-        this.description = description;
+        super(OBJECT_TYPE, permissionId);
+        this.meta.put(NAME_KEY, name);
+        this.meta.put(DESCRIPTION_KEY, description);
+    }
+
+    public Permission(String permissionId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, permissionId, meta);
     }
 
     public String getPermissionId() {
-        return permissionId;
+        return objectId;
     }
 
     public void setPermissionId(String permissionId) {
-        this.permissionId = permissionId;
+        this.objectId = permissionId;
     }
 
     public String getName() {
-        return name;
+        if (meta != null) {
+            if (meta.containsKey(NAME_KEY)) {
+                return meta.get(NAME_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setName(String name) {
-        this.name = name;
+        meta.put(NAME_KEY, name);
     }
 
     public String getDescription() {
-        return description;
+        if (meta != null) {
+            if (meta.containsKey(DESCRIPTION_KEY)) {
+                return meta.get(DESCRIPTION_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        meta.put(DESCRIPTION_KEY, description);
     }
 
     @Override
     public String id() {
-        return permissionId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "permission";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/Permission.java
+++ b/src/main/java/dev/warrant/model/object/Permission.java
@@ -75,9 +75,4 @@ public class Permission extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/PricingTier.java
+++ b/src/main/java/dev/warrant/model/object/PricingTier.java
@@ -1,34 +1,39 @@
 package dev.warrant.model.object;
 
-public class PricingTier implements WarrantObject {
-    public static final String OBJECT_TYPE = "pricing-tier";
+import java.util.Map;
 
-    private String pricingTierId;
+public class PricingTier extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "pricing-tier";
 
     public PricingTier() {
         // For json serialization
+        super();
     }
 
     public PricingTier(String pricingTierId) {
-        this.pricingTierId = pricingTierId;
+        super(OBJECT_TYPE, pricingTierId);
+    }
+
+    public PricingTier(String pricingTierId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, pricingTierId, meta);
     }
 
     public String getPricingTierId() {
-        return pricingTierId;
+        return objectId;
     }
 
     public void setPricingTierId(String pricingTierId) {
-        this.pricingTierId = pricingTierId;
+        this.objectId = pricingTierId;
     }
 
     @Override
     public String id() {
-        return pricingTierId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "pricing-tier";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/PricingTier.java
+++ b/src/main/java/dev/warrant/model/object/PricingTier.java
@@ -35,9 +35,4 @@ public class PricingTier extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/Role.java
+++ b/src/main/java/dev/warrant/model/object/Role.java
@@ -80,9 +80,4 @@ public class Role extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/Role.java
+++ b/src/main/java/dev/warrant/model/object/Role.java
@@ -1,63 +1,84 @@
 package dev.warrant.model.object;
 
-public class Role implements WarrantObject {
-    public static final String OBJECT_TYPE = "role";
+import java.util.Map;
 
-    private String roleId;
-    private String name;
-    private String description;
+public class Role extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "role";
+    static final String NAME_KEY = "name";
+    static final String DESCRIPTION_KEY = "description";
 
     public Role() {
         // For json serialization
+        super();
     }
 
     public Role(String roleId) {
-        this.roleId = roleId;
+        super(OBJECT_TYPE, roleId);
     }
 
     public Role(String roleId, String name) {
-        this.roleId = roleId;
-        this.name = name;
+        super(OBJECT_TYPE, roleId);
+        this.meta.put(NAME_KEY, name);
     }
 
     public Role(String roleId, String name, String description) {
-        this.roleId = roleId;
-        this.name = name;
-        this.description = description;
+        super(OBJECT_TYPE, roleId);
+        this.meta.put(NAME_KEY, name);
+        this.meta.put(DESCRIPTION_KEY, description);
+    }
+
+    public Role(String roleId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, roleId, meta);
     }
 
     public String getRoleId() {
-        return roleId;
+        return objectId;
     }
 
     public void setRoleId(String roleId) {
-        this.roleId = roleId;
+        this.objectId = roleId;
     }
 
     public String getName() {
-        return name;
+        if (meta != null) {
+            if (meta.containsKey(NAME_KEY)) {
+                return meta.get(NAME_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setName(String name) {
-        this.name = name;
+        meta.put(NAME_KEY, name);
     }
 
     public String getDescription() {
-        return description;
+        if (meta != null) {
+            if (meta.containsKey(DESCRIPTION_KEY)) {
+                return meta.get(DESCRIPTION_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        meta.put(DESCRIPTION_KEY, description);
     }
 
     @Override
     public String id() {
-        return roleId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "role";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/Tenant.java
+++ b/src/main/java/dev/warrant/model/object/Tenant.java
@@ -1,48 +1,61 @@
 package dev.warrant.model.object;
 
-public class Tenant implements WarrantObject {
-    public static final String OBJECT_TYPE = "tenant";
+import java.util.Map;
 
-    private String tenantId;
-    private String name;
+public class Tenant extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "tenant";
+    static final String NAME_KEY = "name";
 
     public Tenant() {
         // For json serialization
+        super();
     }
 
     public Tenant(String tenantId) {
-        this.tenantId = tenantId;
+        super(OBJECT_TYPE, tenantId);
     }
 
     public Tenant(String tenantId, String name) {
-        this.tenantId = tenantId;
-        this.name = name;
+        super(OBJECT_TYPE, tenantId);
+        this.meta.put(NAME_KEY, name);
+    }
+
+    public Tenant(String tenantId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, tenantId, meta);
     }
 
     public String getTenantId() {
-        return tenantId;
+        return objectId;
     }
 
     public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
+        this.objectId = tenantId;
     }
 
     public String getName() {
-        return name;
+        if (meta != null) {
+            if (meta.containsKey(NAME_KEY)) {
+                return meta.get(NAME_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setName(String name) {
-        this.name = name;
+        meta.put(NAME_KEY, name);
     }
 
     @Override
     public String id() {
-        return tenantId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "tenant";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/Tenant.java
+++ b/src/main/java/dev/warrant/model/object/Tenant.java
@@ -57,9 +57,4 @@ public class Tenant extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/User.java
+++ b/src/main/java/dev/warrant/model/object/User.java
@@ -1,48 +1,61 @@
 package dev.warrant.model.object;
 
-public class User implements WarrantObject {
-    public static final String OBJECT_TYPE = "user";
+import java.util.Map;
 
-    private String userId;
-    private String email;
+public class User extends BaseWarrantObject {
+    public static final String OBJECT_TYPE = "user";
+    static final String EMAIL_KEY = "email";
 
     public User() {
         // For json serialization
+        super();
     }
 
     public User(String userId) {
-        this.userId = userId;
+        super(OBJECT_TYPE, userId);
     }
 
     public User(String userId, String email) {
-        this.userId = userId;
-        this.email = email;
+        super(OBJECT_TYPE, userId);
+        this.meta.put(EMAIL_KEY, email);
+    }
+
+    public User(String userId, Map<String, Object> meta) {
+        super(OBJECT_TYPE, userId, meta);
     }
 
     public String getUserId() {
-        return userId;
+        return objectId;
     }
 
     public void setUserId(String userId) {
-        this.userId = userId;
+        this.objectId = userId;
     }
 
     public String getEmail() {
-        return email;
+        if (meta != null) {
+            if (meta.containsKey(EMAIL_KEY)) {
+                return meta.get(EMAIL_KEY).toString();
+            } else {
+                return "";
+            }
+        } else {
+            return "";
+        }
     }
 
     public void setEmail(String email) {
-        this.email = email;
+        meta.put(EMAIL_KEY, email);
     }
 
     @Override
     public String id() {
-        return userId;
+        return objectId;
     }
 
     @Override
     public String type() {
-        return "user";
+        return OBJECT_TYPE;
     }
 
     // @Override

--- a/src/main/java/dev/warrant/model/object/User.java
+++ b/src/main/java/dev/warrant/model/object/User.java
@@ -57,9 +57,4 @@ public class User extends BaseWarrantObject {
     public String type() {
         return OBJECT_TYPE;
     }
-
-    // @Override
-    // public Map<String, Object> meta() {
-    //     return null;
-    // }
 }

--- a/src/main/java/dev/warrant/model/object/WarrantListResult.java
+++ b/src/main/java/dev/warrant/model/object/WarrantListResult.java
@@ -1,27 +1,32 @@
-package dev.warrant.model;
+package dev.warrant.model.object;
 
-public class QueryResultSet {
+import dev.warrant.model.Warrant;
 
-    private QueryResult[] results;
+public class WarrantListResult {
+    private Warrant[] results;
     private String prevCursor;
     private String nextCursor;
 
-    public QueryResultSet() {
+    public WarrantListResult() {
         // For json serialization
     }
 
-    public QueryResultSet(QueryResult[] results) {
+    public WarrantListResult(Warrant[] results) {
         this.results = results;
     }
 
-    public QueryResultSet(QueryResult[] results, String prevCursor, String nextCursor) {
+    public WarrantListResult(Warrant[] results, String prevCursor, String nextCursor) {
         this.results = results;
         this.prevCursor = prevCursor;
         this.nextCursor = nextCursor;
     }
 
-    public QueryResult[] getResults() {
-        return this.results;
+    public Warrant[] getResults() {
+        return results;
+    }
+
+    public void setResults(Warrant[] results) {
+        this.results = results;
     }
 
     public String getPrevCursor() {

--- a/src/main/java/dev/warrant/model/object/WarrantObject.java
+++ b/src/main/java/dev/warrant/model/object/WarrantObject.java
@@ -1,9 +1,11 @@
 package dev.warrant.model.object;
 
+import java.util.Map;
+
 public interface WarrantObject {
     public String id();
 
     public String type();
 
-    // public Map<String, Object> meta();
+    public Map<String, Object> meta();
 }

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -219,6 +219,11 @@ public class LiveTest {
         Assertions.assertNotNull(roleGeneratedId.getObjectId());
         Assertions.assertNull(roleGeneratedId.getMeta());
 
+        BaseWarrantObject roleObject = new BaseWarrantObject("role", "manager");
+        BaseWarrantObject createdRoleObject = client.createObject(roleObject);
+        Assertions.assertEquals("role", createdRoleObject.getObjectType());
+        Assertions.assertEquals("manager", createdRoleObject.getObjectId());
+
         Map<String, Object> meta = new HashMap<>();
         meta.put("name", "admin role");
         BaseWarrantObject roleWithMeta = client.createObject("role", "admin", meta);

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -19,7 +19,7 @@ import dev.warrant.model.WarrantSubject;
 import dev.warrant.model.object.BaseWarrantObject;
 import dev.warrant.model.object.Feature;
 import dev.warrant.model.object.ListResult;
-import dev.warrant.model.object.BaseListResult;
+import dev.warrant.model.object.BaseWarrantObjectListResult;
 import dev.warrant.model.object.Permission;
 import dev.warrant.model.object.PricingTier;
 import dev.warrant.model.object.Role;
@@ -247,7 +247,7 @@ public class LiveTest {
         Assertions.assertEquals(updatedRole.getObjectId(), fetchedObj.getObjectId());
         Assertions.assertEquals(updatedRole.getMeta(), fetchedObj.getMeta());
 
-        BaseListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
+        BaseWarrantObjectListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
         BaseWarrantObject[] fetchedObjects = fetchedObjectsList.getResults();
         Assertions.assertEquals(2, fetchedObjects.length);
         Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObjects[0].getObjectType());
@@ -269,7 +269,7 @@ public class LiveTest {
         });
         Assertions.assertEquals(3, objects.length);
 
-        BaseListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10), new RequestOptions().withWarrantToken("latest"));
+        BaseWarrantObjectListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10), new RequestOptions().withWarrantToken("latest"));
         BaseWarrantObject[] fetchedObjects = fetchedObjectsList.getResults();
         Assertions.assertEquals(3, fetchedObjects.length);
         Assertions.assertEquals("document", fetchedObjects[0].getObjectType());

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -59,8 +59,10 @@ public class LiveTest {
         ListResult<User> usersListResult = client.listUsers(listParams, requestOptions);
         Assertions.assertEquals(2, usersListResult.getResults().length);
 
-        client.deleteUser(user1);
-        client.deleteUser(user2);
+        String warrantToken = client.deleteUser(user1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken =client.deleteUser(user2);
+        Assertions.assertNotNull(warrantToken);
         usersListResult = client.listUsers(10, requestOptions);
         Assertions.assertEquals(0, usersListResult.getResults().length);
     }
@@ -85,8 +87,10 @@ public class LiveTest {
         ListResult<Tenant> tenantsListResult = client.listTenants(10, requestOptions);
         Assertions.assertEquals(2, tenantsListResult.getResults().length);
 
-        client.deleteTenant(tenant1);
-        client.deleteTenant(tenant2);
+        String warrantToken = client.deleteTenant(tenant1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenant(tenant2);
+        Assertions.assertNotNull(warrantToken);
         tenantsListResult = client.listTenants(10, requestOptions);
         Assertions.assertEquals(0, tenantsListResult.getResults().length);
     }
@@ -119,9 +123,12 @@ public class LiveTest {
         ListResult<Role> rolesListResult = client.listRoles(10, requestOptions);
         Assertions.assertEquals(3, rolesListResult.getResults().length);
 
-        client.deleteRole(role1);
-        client.deleteRole(adminRole);
-        client.deleteRole(viewerRole);
+        String warrantToken = client.deleteRole(role1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(adminRole);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(viewerRole);
+        Assertions.assertNotNull(warrantToken);
         rolesListResult = client.listRoles(10, requestOptions);
         Assertions.assertEquals(0, rolesListResult.getResults().length);
     }
@@ -156,9 +163,12 @@ public class LiveTest {
         ListResult<Permission> permissionsListResult = client.listPermissions(10, requestOptions);
         Assertions.assertEquals(3, permissionsListResult.getResults().length);
 
-        client.deletePermission(generatedPermissionId);
-        client.deletePermission(permission1);
-        client.deletePermission(permission2);
+        String warrantToken = client.deletePermission(generatedPermissionId);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission2);
+        Assertions.assertNotNull(warrantToken);
         permissionsListResult = client.listPermissions(10, requestOptions);
         Assertions.assertEquals(0, permissionsListResult.getResults().length);
     }
@@ -182,9 +192,12 @@ public class LiveTest {
         ListResult<Feature> featuresListResult = client.listFeatures(10, requestOptions);
         Assertions.assertEquals(3, featuresListResult.getResults().length);
 
-        client.deleteFeature(generatedFeatureId);
-        client.deleteFeature(feature1);
-        client.deleteFeature(feature2);
+        String warrantToken = client.deleteFeature(generatedFeatureId);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature2);
+        Assertions.assertNotNull(warrantToken);
         featuresListResult = client.listFeatures(10, requestOptions);
         Assertions.assertEquals(0, featuresListResult.getResults().length);
     }
@@ -205,9 +218,12 @@ public class LiveTest {
         ListResult<PricingTier> tiersListResult = client.listPricingTiers(10, requestOptions);
         Assertions.assertEquals(3, tiersListResult.getResults().length);
 
-        client.deletePricingTier(generatedTier);
-        client.deletePricingTier(tier1);
-        client.deletePricingTier(tier2);
+        String warrantToken = client.deletePricingTier(generatedTier);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(tier1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(tier2);
+        Assertions.assertNotNull(warrantToken);
         tiersListResult = client.listPricingTiers(10, requestOptions);
         Assertions.assertEquals(0, tiersListResult.getResults().length);
     }
@@ -263,9 +279,12 @@ public class LiveTest {
         Assertions.assertEquals(roleObject.getObjectType(), fetchedObjects[0].getObjectType());
         Assertions.assertEquals(roleObject.getObjectId(), fetchedObjects[0].getObjectId());
 
-        client.deleteObject(roleObject);
-        client.deleteObject(roleGeneratedId);
-        client.deleteObject(roleWithMeta);
+        String warrantToken = client.deleteObject(roleObject);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteObject(roleGeneratedId);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteObject(roleWithMeta);
+        Assertions.assertNotNull(warrantToken);
 
         fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
         Assertions.assertEquals(0, fetchedObjectsList.getResults().length);
@@ -290,11 +309,12 @@ public class LiveTest {
         Assertions.assertEquals("folder", fetchedObjects[2].getObjectType());
         Assertions.assertEquals("resources", fetchedObjects[2].getObjectId());
 
-        client.deleteObjects(new BaseWarrantObject[]{
+        String warrantToken = client.deleteObjects(new BaseWarrantObject[]{
             new BaseWarrantObject("document", "document-a"),
             new BaseWarrantObject("document", "document-b"),
             new BaseWarrantObject("folder", "resources")
         });
+        Assertions.assertNotNull(warrantToken);
         fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10), new RequestOptions().withWarrantToken("latest"));
         fetchedObjects = fetchedObjectsList.getResults();
         Assertions.assertEquals(0, fetchedObjects.length);
@@ -314,14 +334,16 @@ public class LiveTest {
         Assertions.assertEquals("tenant-1", createdTenants[0].getTenantId());
         Assertions.assertEquals("tenant-2", createdTenants[1].getTenantId());
 
-        client.deleteUsers(new User[]{
+        String warrantToken = client.deleteUsers(new User[]{
             new User("user-1"),
             new User("user-2")
         });
-        client.deleteTenants(new Tenant[]{
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenants(new Tenant[]{
             new Tenant("tenant-1"),
             new Tenant("tenant-2")
         });
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -350,10 +372,14 @@ public class LiveTest {
         Assertions.assertEquals(0, client.listTenantsForUser(user1, 100, requestOptions).getResults().length);
 
         // Clean up
-        client.deleteUser(user1);
-        client.deleteUser(user2);
-        client.deleteTenant(tenant1);
-        client.deleteTenant(tenant2);
+        String warrantToken = client.deleteUser(user1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(user2);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenant(tenant1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenant(tenant2);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -405,12 +431,18 @@ public class LiveTest {
         Assertions.assertEquals(0, client.listPermissionsForUser(viewer, 100, requestOptions).getResults().length);
 
         // Clean up
-        client.deleteUser(adminUser);
-        client.deleteUser(viewer);
-        client.deleteRole(adminRole);
-        client.deleteRole(viewerRole);
-        client.deletePermission(createPermission);
-        client.deletePermission(viewPermission);
+        String warrantToken = client.deleteUser(adminUser);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(viewer);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(adminRole);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(viewerRole);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(createPermission);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(viewPermission);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -462,13 +494,20 @@ public class LiveTest {
         Assertions.assertEquals(0, client.listPricingTiersForUser(freeUser, 100, requestOptions).getResults().length);
 
         // Clean up
-        client.deleteUser(freeUser);
-        client.deleteUser(paidUser);
-        client.deletePricingTier(freeTier);
-        client.deletePricingTier(paidTier);
-        client.deleteFeature(customFeature);
-        client.deleteFeature(feature1);
-        client.deleteFeature(feature2);
+        String warrantToken = client.deleteUser(freeUser);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(paidUser);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(freeTier);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(paidTier);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(customFeature);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature2);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -520,13 +559,20 @@ public class LiveTest {
         Assertions.assertEquals(0, client.listPricingTiersForTenant(freeTenant, 100, requestOptions).getResults().length);
 
         // Clean up
-        client.deleteTenant(freeTenant);
-        client.deleteTenant(paidTenant);
-        client.deletePricingTier(freeTier);
-        client.deletePricingTier(paidTier);
-        client.deleteFeature(customFeature);
-        client.deleteFeature(feature1);
-        client.deleteFeature(feature2);
+        String warrantToken = client.deleteTenant(freeTenant);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenant(paidTenant);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(freeTier);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePricingTier(paidTier);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(customFeature);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteFeature(feature2);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -540,8 +586,10 @@ public class LiveTest {
                 .assertNotNull(client.createUserSelfServiceDashboardUrl(user.getUserId(), tenant.getTenantId(), "rbac",
                         "http://localhost:8080"));
 
-        client.deleteUser(user);
-        client.deleteTenant(tenant);
+        String warrantToken = client.deleteUser(user);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteTenant(tenant);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -576,10 +624,14 @@ public class LiveTest {
         Assertions.assertNotNull(warrantToken);
         warrantToken = client.deleteWarrant(role1, "member", subject);
         Assertions.assertNotNull(warrantToken);
-        client.deletePermission(permission1);
-        client.deletePermission(permission2);
-        client.deleteRole(role1);
-        client.deleteUser(user);
+        warrantToken = client.deletePermission(permission1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission2);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(role1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(user);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -593,15 +645,17 @@ public class LiveTest {
         Assertions.assertTrue(client.check(new BaseWarrantObject("permission", "perm1"), "member", new WarrantSubject("user", "user1")));
         Assertions.assertTrue(client.check(new BaseWarrantObject("permission", "perm2"), "member", new WarrantSubject("user", "user1")));
 
-        client.deleteWarrants(new Warrant[]{
+        String warrantToken = client.deleteWarrants(new Warrant[]{
             new Warrant("permission", "perm1", "member", new WarrantSubject("user", "user1")),
             new Warrant("permission", "perm2", "member", new WarrantSubject("user", "user1"))
         });
-        client.deleteObjects(new BaseWarrantObject[]{
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteObjects(new BaseWarrantObject[]{
             new BaseWarrantObject("permission", "perm1"),
             new BaseWarrantObject("permission", "perm2"),
             new BaseWarrantObject("user", "user1")
         });
+        Assertions.assertNotNull(warrantToken);
 
         Assertions.assertEquals(0, client.listWarrants(new WarrantFilters(), new ListParams(), new RequestOptions().withWarrantToken("latest")).getResults().length);
     }
@@ -627,10 +681,13 @@ public class LiveTest {
         Assertions.assertFalse(client.check(testPermission, "member",
                 new WarrantSubject(testUser.type(), testUser.id()), warrantContext, requestOptions));
 
-        client.deleteWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()),
+        String warrantToken = client.deleteWarrant(testPermission, "member", new WarrantSubject(testUser.type(), testUser.id()),
                 "geo == 'us' && isActivated == true");
-        client.deleteUser(testUser);
-        client.deletePermission(testPermission);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(testUser);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(testPermission);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -665,12 +722,18 @@ public class LiveTest {
         result = client.checkAllOf(checks);
         Assertions.assertFalse(result.isAuthorized());
 
-        client.deleteWarrant(permission1, "member", userSubject);
-        client.deleteWarrant(permission2, "member", userSubject);
-        client.deleteUser(user);
-        client.deletePermission(permission1);
-        client.deletePermission(permission2);
-        client.deletePermission(permission3);
+        String warrantToken = client.deleteWarrant(permission1, "member", userSubject);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteWarrant(permission2, "member", userSubject);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(user);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission2);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission3);
+        Assertions.assertNotNull(warrantToken);
     }
 
     @Test
@@ -716,12 +779,19 @@ public class LiveTest {
         Assertions.assertEquals("role", resultSet.getResults()[0].getWarrant().getSubject().getObjectType());
         Assertions.assertEquals("role1", resultSet.getResults()[0].getWarrant().getSubject().getObjectId());
 
-        client.deleteRole(role1);
-        client.deleteRole(role2);
-        client.deletePermission(permission3);
-        client.deletePermission(permission2);
-        client.deletePermission(permission1);
-        client.deleteUser(userB);
-        client.deleteUser(userA);
+        String warrantToken = client.deleteRole(role1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteRole(role2);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission3);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission2);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deletePermission(permission1);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(userB);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteUser(userA);
+        Assertions.assertNotNull(warrantToken);
     }
 }

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -187,38 +187,36 @@ public class LiveTest {
 
     @Test
     public void crudObjects() throws WarrantException {
-        // BaseWarrantObject roleGeneratedId = client.createObject("role");
-        // Assertions.assertEquals("role", roleGeneratedId.getObjectType());
-        // Assertions.assertNotNull(roleGeneratedId.getObjectId());
-        // Assertions.assertNull(roleGeneratedId.getMeta());
+        BaseWarrantObject roleGeneratedId = client.createObject("role");
+        Assertions.assertEquals("role", roleGeneratedId.getObjectType());
+        Assertions.assertNotNull(roleGeneratedId.getObjectId());
+        Assertions.assertNull(roleGeneratedId.getMeta());
 
-        // Map<String, Object> meta = new HashMap<>();
-        // meta.put("name", "admin role");
-        // BaseWarrantObject roleWithMeta = client.createObject("role", "admin", meta);
-        // Assertions.assertEquals("role", roleWithMeta.getObjectType());
-        // Assertions.assertEquals("admin", roleWithMeta.getObjectId());
-        // Assertions.assertNotNull(roleWithMeta.getMeta());
-        // Assertions.assertEquals("admin role", roleWithMeta.getMeta().get("name"));
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("name", "admin role");
+        BaseWarrantObject roleWithMeta = client.createObject("role", "admin", meta);
+        Assertions.assertEquals("role", roleWithMeta.getObjectType());
+        Assertions.assertEquals("admin", roleWithMeta.getObjectId());
+        Assertions.assertNotNull(roleWithMeta.getMeta());
+        Assertions.assertEquals("admin role", roleWithMeta.getMeta().get("name"));
 
-        // Map<String, Object> updatedMeta = new HashMap<>();
-        // updatedMeta.put("name", "admin role");
-        // updatedMeta.put("description", "role description");
-        // BaseWarrantObject updatedRole = client.updateObject(roleWithMeta.getObjectType(), roleWithMeta.getObjectId(), updatedMeta);
-        // Assertions.assertEquals(roleWithMeta.getObjectType(), updatedRole.getObjectType());
-        // Assertions.assertEquals(roleWithMeta.getObjectId(), updatedRole.getObjectId());
-        // Assertions.assertEquals(2, updatedRole.getMeta().size());
-        // Assertions.assertEquals("admin role", updatedRole.getMeta().get("name"));
-        // Assertions.assertEquals("role description", updatedRole.getMeta().get("description"));
+        Map<String, Object> updatedMeta = new HashMap<>();
+        updatedMeta.put("name", "admin role");
+        updatedMeta.put("description", "role description");
+        BaseWarrantObject updatedRole = client.updateObject(roleWithMeta.getObjectType(), roleWithMeta.getObjectId(), updatedMeta);
+        Assertions.assertEquals(roleWithMeta.getObjectType(), updatedRole.getObjectType());
+        Assertions.assertEquals(roleWithMeta.getObjectId(), updatedRole.getObjectId());
+        Assertions.assertEquals(2, updatedRole.getMeta().size());
+        Assertions.assertEquals("admin role", updatedRole.getMeta().get("name"));
+        Assertions.assertEquals("role description", updatedRole.getMeta().get("description"));
 
-        // BaseWarrantObject fetchedObj = client.getObject(roleGeneratedId.getObjectType(), roleGeneratedId.getObjectId());
-        // Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObj.getObjectType());
-        // Assertions.assertEquals(roleGeneratedId.getObjectId(), fetchedObj.getObjectId());
-        // Assertions.assertEquals(roleGeneratedId.getMeta(), fetchedObj.getMeta());
+        BaseWarrantObject fetchedObj = client.getObject(roleGeneratedId.getObjectType(), roleGeneratedId.getObjectId());
+        Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObj.getObjectType());
+        Assertions.assertEquals(roleGeneratedId.getObjectId(), fetchedObj.getObjectId());
+        Assertions.assertEquals(roleGeneratedId.getMeta(), fetchedObj.getMeta());
 
-        User user = client.createUser(new User("object_test_1", "email@email.com"));
-        Assertions.assertEquals("object_test_1", user.getUserId());
-        Assertions.assertEquals("email@email.com", user.getEmail());
-        client.deleteObject(user);
+        client.deleteObject(roleGeneratedId);
+        client.deleteObject(roleWithMeta);
     }
 
     @Test

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -275,6 +275,7 @@ public class LiveTest {
         Assertions.assertEquals(updatedRole.getMeta(), fetchedObjects[2].getMeta());
 
         fetchedObjectsList = client.listObjects(new ObjectFilters().withQuery("manager"), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
+        fetchedObjects = fetchedObjectsList.getResults();
         Assertions.assertEquals(1, fetchedObjectsList.getResults().length);
         Assertions.assertEquals(roleObject.getObjectType(), fetchedObjects[0].getObjectType());
         Assertions.assertEquals(roleObject.getObjectId(), fetchedObjects[0].getObjectId());

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -16,12 +16,16 @@ import dev.warrant.model.Warrant;
 import dev.warrant.model.WarrantCheck;
 import dev.warrant.model.WarrantSpec;
 import dev.warrant.model.WarrantSubject;
+import dev.warrant.model.object.BaseWarrantObject;
 import dev.warrant.model.object.Feature;
+import dev.warrant.model.object.ListResult;
+import dev.warrant.model.object.BaseListResult;
 import dev.warrant.model.object.Permission;
 import dev.warrant.model.object.PricingTier;
 import dev.warrant.model.object.Role;
 import dev.warrant.model.object.Tenant;
 import dev.warrant.model.object.User;
+import dev.warrant.model.object.WarrantListResult;
 
 @Disabled("Remove this annotation and add your API_KEY below to run these against the live server")
 public class LiveTest {
@@ -38,7 +42,7 @@ public class LiveTest {
     public void crudUsers() throws WarrantException {
         User user1 = client.createUser();
         Assertions.assertNotNull(user1.getUserId());
-        Assertions.assertNull(user1.getEmail());
+        Assertions.assertEquals("", user1.getEmail());
 
         User user2 = client.createUser(new User("some_id", "test@email.com"));
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
@@ -51,21 +55,21 @@ public class LiveTest {
         Assertions.assertEquals("some_id", refetchedUser.getUserId());
         Assertions.assertEquals("updated@email.com", refetchedUser.getEmail());
 
-        ListParams listParams = new ListParams().withLimit(10).withPage(1);
-        User[] users = client.listUsers(listParams, requestOptions);
-        Assertions.assertEquals(2, users.length);
+        ListParams listParams = new ListParams().withLimit(10);
+        ListResult<User> usersListResult = client.listUsers(listParams, requestOptions);
+        Assertions.assertEquals(2, usersListResult.getResults().length);
 
         client.deleteUser(user1);
         client.deleteUser(user2);
-        users = client.listUsers(10, 1, requestOptions);
-        Assertions.assertEquals(0, users.length);
+        usersListResult = client.listUsers(10, requestOptions);
+        Assertions.assertEquals(0, usersListResult.getResults().length);
     }
 
     @Test
     public void crudTenants() throws WarrantException {
         Tenant tenant1 = client.createTenant();
         Assertions.assertNotNull(tenant1.getTenantId());
-        Assertions.assertNull(tenant1.getName());
+        Assertions.assertEquals("", tenant1.getName());
 
         Tenant tenant2 = client.createTenant(new Tenant("some_tenant_Id", "new_name"));
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
@@ -78,17 +82,22 @@ public class LiveTest {
         Assertions.assertEquals("some_tenant_Id", refetchedTenant.getTenantId());
         Assertions.assertEquals("updated_name", refetchedTenant.getName());
 
-        Tenant[] tenants = client.listTenants(10, 1, requestOptions);
-        Assertions.assertEquals(2, tenants.length);
+        ListResult<Tenant> tenantsListResult = client.listTenants(10, requestOptions);
+        Assertions.assertEquals(2, tenantsListResult.getResults().length);
 
         client.deleteTenant(tenant1);
         client.deleteTenant(tenant2);
-        tenants = client.listTenants(10, 1, requestOptions);
-        Assertions.assertEquals(0, tenants.length);
+        tenantsListResult = client.listTenants(10, requestOptions);
+        Assertions.assertEquals(0, tenantsListResult.getResults().length);
     }
 
     @Test
     public void crudRoles() throws WarrantException {
+        Role role1 = client.createRole();
+        Assertions.assertNotNull(role1.getRoleId());
+        Assertions.assertEquals("", role1.getName());
+        Assertions.assertEquals("", role1.getDescription());
+
         Role adminRole = client.createRole(new Role("admin", "Admin", "The admin role"));
         Assertions.assertEquals("admin", adminRole.getRoleId());
         Assertions.assertEquals("Admin", adminRole.getName());
@@ -107,17 +116,23 @@ public class LiveTest {
         Assertions.assertEquals("Viewer Updated", refetchedRole.getName());
         Assertions.assertEquals("Updated desc", refetchedRole.getDescription());
 
-        Role[] roles = client.listRoles(10, 1, requestOptions);
-        Assertions.assertEquals(2, roles.length);
+        ListResult<Role> rolesListResult = client.listRoles(10, requestOptions);
+        Assertions.assertEquals(3, rolesListResult.getResults().length);
 
+        client.deleteRole(role1);
         client.deleteRole(adminRole);
         client.deleteRole(viewerRole);
-        roles = client.listRoles(10, 1, requestOptions);
-        Assertions.assertEquals(0, roles.length);
+        rolesListResult = client.listRoles(10, requestOptions);
+        Assertions.assertEquals(0, rolesListResult.getResults().length);
     }
 
     @Test
     public void crudPermissions() throws WarrantException {
+        Permission generatedPermissionId = client.createPermission();
+        Assertions.assertNotNull(generatedPermissionId.getPermissionId());
+        Assertions.assertEquals("", generatedPermissionId.getName());
+        Assertions.assertEquals("", generatedPermissionId.getDescription());
+
         Permission permission1 = client
                 .createPermission(new Permission("perm1", "Permission 1", "Permission with id 1"));
         Assertions.assertEquals("perm1", permission1.getPermissionId());
@@ -138,36 +153,47 @@ public class LiveTest {
         Assertions.assertEquals("Permission 2 Updated", refetchedPermission.getName());
         Assertions.assertEquals("Updated desc", refetchedPermission.getDescription());
 
-        Permission[] permissions = client.listPermissions(10, 1, requestOptions);
-        Assertions.assertEquals(2, permissions.length);
+        ListResult<Permission> permissionsListResult = client.listPermissions(10, requestOptions);
+        Assertions.assertEquals(3, permissionsListResult.getResults().length);
 
+        client.deletePermission(generatedPermissionId);
         client.deletePermission(permission1);
         client.deletePermission(permission2);
-        permissions = client.listPermissions(10, 1, requestOptions);
-        Assertions.assertEquals(0, permissions.length);
+        permissionsListResult = client.listPermissions(10, requestOptions);
+        Assertions.assertEquals(0, permissionsListResult.getResults().length);
     }
 
     @Test
     public void crudFeatures() throws WarrantException {
-        Feature feature1 = client.createFeature(new Feature("new-feature"));
+        Feature generatedFeatureId = client.createFeature();
+        Assertions.assertNotNull(generatedFeatureId.getFeatureId());
+
+        Map<String, Object> featureMeta = new HashMap<String, Object>();
+        featureMeta.put("description", "A new feature");
+        Feature feature1 = client.createFeature(new Feature("new-feature", featureMeta));
         Assertions.assertEquals("new-feature", feature1.getFeatureId());
+        Assertions.assertEquals("A new feature", feature1.getMeta().get("description"));
 
         Feature feature2 = client.createFeature(new Feature("feature-2"));
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
         Feature refetchedFeature = client.getFeature(feature2.getFeatureId(), requestOptions);
         Assertions.assertEquals(feature2.getFeatureId(), refetchedFeature.getFeatureId());
 
-        Feature[] features = client.listFeatures(10, 1, requestOptions);
-        Assertions.assertEquals(2, features.length);
+        ListResult<Feature> featuresListResult = client.listFeatures(10, requestOptions);
+        Assertions.assertEquals(3, featuresListResult.getResults().length);
 
+        client.deleteFeature(generatedFeatureId);
         client.deleteFeature(feature1);
         client.deleteFeature(feature2);
-        features = client.listFeatures(10, 1, requestOptions);
-        Assertions.assertEquals(0, features.length);
+        featuresListResult = client.listFeatures(10, requestOptions);
+        Assertions.assertEquals(0, featuresListResult.getResults().length);
     }
 
     @Test
     public void crudPricingTiers() throws WarrantException {
+        PricingTier generatedTier = client.createPricingTier();
+        Assertions.assertNotNull(generatedTier.getPricingTierId());
+
         PricingTier tier1 = client.createPricingTier(new PricingTier("new-tier1"));
         Assertions.assertEquals("new-tier1", tier1.getPricingTierId());
 
@@ -176,13 +202,14 @@ public class LiveTest {
         PricingTier refetchedTier = client.getPricingTier(tier2.getPricingTierId(), requestOptions);
         Assertions.assertEquals(tier2.getPricingTierId(), refetchedTier.getPricingTierId());
 
-        PricingTier[] tiers = client.listPricingTiers(10, 1, requestOptions);
-        Assertions.assertEquals(2, tiers.length);
+        ListResult<PricingTier> tiersListResult = client.listPricingTiers(10, requestOptions);
+        Assertions.assertEquals(3, tiersListResult.getResults().length);
 
+        client.deletePricingTier(generatedTier);
         client.deletePricingTier(tier1);
         client.deletePricingTier(tier2);
-        tiers = client.listPricingTiers(10, 1, requestOptions);
-        Assertions.assertEquals(0, tiers.length);
+        tiersListResult = client.listPricingTiers(10, requestOptions);
+        Assertions.assertEquals(0, tiersListResult.getResults().length);
     }
 
     @Test
@@ -210,17 +237,55 @@ public class LiveTest {
         Assertions.assertEquals("admin role", updatedRole.getMeta().get("name"));
         Assertions.assertEquals("role description", updatedRole.getMeta().get("description"));
 
-        BaseWarrantObject fetchedObj = client.getObject(roleGeneratedId.getObjectType(), roleGeneratedId.getObjectId());
-        Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObj.getObjectType());
-        Assertions.assertEquals(roleGeneratedId.getObjectId(), fetchedObj.getObjectId());
-        Assertions.assertEquals(roleGeneratedId.getMeta(), fetchedObj.getMeta());
+        BaseWarrantObject fetchedObj = client.getObject(updatedRole.getObjectType(), updatedRole.getObjectId());
+        Assertions.assertEquals(updatedRole.getObjectType(), fetchedObj.getObjectType());
+        Assertions.assertEquals(updatedRole.getObjectId(), fetchedObj.getObjectId());
+        Assertions.assertEquals(updatedRole.getMeta(), fetchedObj.getMeta());
+
+        BaseListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
+        BaseWarrantObject[] fetchedObjects = fetchedObjectsList.getResults();
+        Assertions.assertEquals(2, fetchedObjects.length);
+        Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObjects[0].getObjectType());
+        Assertions.assertEquals(roleGeneratedId.getObjectId(), fetchedObjects[0].getObjectId());
+        Assertions.assertEquals(updatedRole.getObjectType(), fetchedObjects[1].getObjectType());
+        Assertions.assertEquals(updatedRole.getObjectId(), fetchedObjects[1].getObjectId());
+        Assertions.assertEquals(updatedRole.getMeta(), fetchedObjects[1].getMeta());
 
         client.deleteObject(roleGeneratedId);
         client.deleteObject(roleWithMeta);
     }
 
     @Test
-    public void batchCreateUsersAndTenants() throws WarrantException {
+    public void batchCreateAndDeleteObjects() throws WarrantException {
+        BaseWarrantObject[] objects = client.createObjects(new BaseWarrantObject[]{
+            new BaseWarrantObject("document", "document-a"),
+            new BaseWarrantObject("document", "document-b"),
+            new BaseWarrantObject("folder", "resources")
+        });
+        Assertions.assertEquals(3, objects.length);
+
+        BaseListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10), new RequestOptions().withWarrantToken("latest"));
+        BaseWarrantObject[] fetchedObjects = fetchedObjectsList.getResults();
+        Assertions.assertEquals(3, fetchedObjects.length);
+        Assertions.assertEquals("document", fetchedObjects[0].getObjectType());
+        Assertions.assertEquals("document-a", fetchedObjects[0].getObjectId());
+        Assertions.assertEquals("document", fetchedObjects[1].getObjectType());
+        Assertions.assertEquals("document-b", fetchedObjects[1].getObjectId());
+        Assertions.assertEquals("folder", fetchedObjects[2].getObjectType());
+        Assertions.assertEquals("resources", fetchedObjects[2].getObjectId());
+
+        client.deleteObjects(new BaseWarrantObject[]{
+            new BaseWarrantObject("document", "document-a"),
+            new BaseWarrantObject("document", "document-b"),
+            new BaseWarrantObject("folder", "resources")
+        });
+        fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10), new RequestOptions().withWarrantToken("latest"));
+        fetchedObjects = fetchedObjectsList.getResults();
+        Assertions.assertEquals(0, fetchedObjects.length);
+    }
+
+    @Test
+    public void batchCreateAndDeleteUsersAndTenants() throws WarrantException {
         User[] newUsers = { new User("user-1"), new User("user-2") };
         User[] createdUsers = client.createUsers(newUsers);
         Assertions.assertEquals(2, createdUsers.length);
@@ -233,10 +298,14 @@ public class LiveTest {
         Assertions.assertEquals("tenant-1", createdTenants[0].getTenantId());
         Assertions.assertEquals("tenant-2", createdTenants[1].getTenantId());
 
-        client.deleteUser("user-1");
-        client.deleteUser("user-2");
-        client.deleteTenant("tenant-1");
-        client.deleteTenant("tenant-2");
+        client.deleteUsers(new User[]{
+            new User("user-1"),
+            new User("user-2")
+        });
+        client.deleteTenants(new Tenant[]{
+            new Tenant("tenant-1"),
+            new Tenant("tenant-2")
+        });
     }
 
     @Test
@@ -251,18 +320,18 @@ public class LiveTest {
 
         // Assign user1 -> tenant1
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
-        Assertions.assertEquals(0, client.listTenantsForUser(user1, 100, 1, requestOptions).length);
-        Assertions.assertEquals(0, client.listUsersForTenant("tenant-1", 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listTenantsForUser(user1, 100, requestOptions).getResults().length);
+        Assertions.assertEquals(0, client.listUsersForTenant("tenant-1", 100, requestOptions).getResults().length);
         client.assignUserToTenant(user1, tenant1);
-        Tenant[] tenants = client.listTenantsForUser(user1, 100, 1, requestOptions);
-        Assertions.assertEquals(1, tenants.length);
-        Assertions.assertEquals("tenant-1", tenants[0].getTenantId());
-        User[] users = client.listUsersForTenant("tenant-1", 100, 1, requestOptions);
-        Assertions.assertEquals(1, users.length);
-        Assertions.assertEquals(user1.getUserId(), users[0].getUserId());
-        Assertions.assertEquals(1, client.listTenantsForUser(user1, 100, 1, requestOptions).length);
+        ListResult<Tenant> tenantsListResult = client.listTenantsForUser(user1, 100, requestOptions);
+        Assertions.assertEquals(1, tenantsListResult.getResults().length);
+        Assertions.assertEquals("tenant-1", tenantsListResult.getResults()[0].getTenantId());
+        ListResult<User> users = client.listUsersForTenant("tenant-1", 100, requestOptions);
+        Assertions.assertEquals(1, users.getResults().length);
+        Assertions.assertEquals(user1.getUserId(), users.getResults()[0].getUserId());
+        Assertions.assertEquals(1, client.listTenantsForUser(user1, 100, requestOptions).getResults().length);
         client.removeUserFromTenant(user1, tenant1);
-        Assertions.assertEquals(0, client.listTenantsForUser(user1, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listTenantsForUser(user1, 100, requestOptions).getResults().length);
 
         // Clean up
         client.deleteUser(user1);
@@ -289,35 +358,35 @@ public class LiveTest {
 
         // Assign 'create-report' -> admin role -> admin user
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
-        Assertions.assertEquals(0, client.listRolesForUser(adminUser, 100, 1, requestOptions).length);
-        Assertions.assertEquals(0, client.listPermissionsForRole(adminRole, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listRolesForUser(adminUser, 100, requestOptions).getResults().length);
+        Assertions.assertEquals(0, client.listPermissionsForRole(adminRole, 100, requestOptions).getResults().length);
         Assertions.assertFalse(client.checkUserHasPermission(adminUser, "create-report", requestOptions));
         client.assignPermissionToRole(createPermission, adminRole);
         client.assignRoleToUser(adminRole, adminUser);
-        Permission[] adminPermissions = client.listPermissionsForRole(adminRole, 100, 1, requestOptions);
-        Assertions.assertEquals(1, adminPermissions.length);
-        Assertions.assertEquals("create-report", adminPermissions[0].getPermissionId());
+        ListResult<Permission> adminPermissionsListResult = client.listPermissionsForRole(adminRole, 100, requestOptions);
+        Assertions.assertEquals(1, adminPermissionsListResult.getResults().length);
+        Assertions.assertEquals("create-report", adminPermissionsListResult.getResults()[0].getPermissionId());
         Assertions.assertTrue(client.checkUserHasPermission(adminUser, "create-report", requestOptions));
-        Role[] userRoles = client.listRolesForUser(adminUser, 100, 1, requestOptions);
-        Assertions.assertEquals(1, userRoles.length);
-        Assertions.assertEquals("admin", userRoles[0].getRoleId());
+        ListResult<Role> userRolesListResult = client.listRolesForUser(adminUser, 100, requestOptions);
+        Assertions.assertEquals(1, userRolesListResult.getResults().length);
+        Assertions.assertEquals("admin", userRolesListResult.getResults()[0].getRoleId());
         client.removePermissionFromRole(createPermission, adminRole);
         Assertions.assertFalse(client.checkUserHasPermission(adminUser, "create-report", requestOptions));
-        Assertions.assertEquals(1, client.listRolesForUser(adminUser.getUserId(), 100, 1, requestOptions).length);
+        Assertions.assertEquals(1, client.listRolesForUser(adminUser.getUserId(), 100, requestOptions).getResults().length);
         client.removeRoleFromUser(adminRole, adminUser);
-        Assertions.assertEquals(0, client.listRolesForUser(adminUser.getUserId(), 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listRolesForUser(adminUser.getUserId(), 100, requestOptions).getResults().length);
 
         // Assign 'view-report' -> viewer user
         Assertions.assertFalse(client.checkUserHasPermission(viewer, "view-report", requestOptions));
-        Assertions.assertEquals(0, client.listPermissionsForUser(viewer, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listPermissionsForUser(viewer, 100, requestOptions).getResults().length);
         client.assignPermissionToUser(viewPermission, viewer);
         Assertions.assertTrue(client.checkUserHasPermission(viewer, "view-report", requestOptions));
-        Permission[] userPermissions = client.listPermissionsForUser(viewer, 100, 1, requestOptions);
-        Assertions.assertEquals(1, userPermissions.length);
-        Assertions.assertEquals("view-report", userPermissions[0].getPermissionId());
+        ListResult<Permission> userPermissionsListResult = client.listPermissionsForUser(viewer, 100, requestOptions);
+        Assertions.assertEquals(1, userPermissionsListResult.getResults().length);
+        Assertions.assertEquals("view-report", userPermissionsListResult.getResults()[0].getPermissionId());
         client.removePermissionFromUser(viewPermission, viewer);
         Assertions.assertFalse(client.checkUserHasPermission(viewer, "view-report", requestOptions));
-        Assertions.assertEquals(0, client.listPermissionsForUser(viewer, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listPermissionsForUser(viewer, 100, requestOptions).getResults().length);
 
         // Clean up
         client.deleteUser(adminUser);
@@ -346,35 +415,35 @@ public class LiveTest {
         // Assign 'custom-feature' -> paid user
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
         Assertions.assertFalse(client.checkUserHasFeature(paidUser, "custom-feature", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForUser(paidUser, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForUser(paidUser, 100, requestOptions).getResults().length);
         client.assignFeatureToUser(customFeature, paidUser);
         Assertions.assertTrue(client.checkUserHasFeature(paidUser, "custom-feature", requestOptions));
-        Feature[] paidUserFeatures = client.listFeaturesForUser(paidUser, 100, 1, requestOptions);
-        Assertions.assertEquals(1, paidUserFeatures.length);
-        Assertions.assertEquals("custom-feature", paidUserFeatures[0].getFeatureId());
+        ListResult<Feature> paidUserFeaturesListResult = client.listFeaturesForUser(paidUser, 100, requestOptions);
+        Assertions.assertEquals(1, paidUserFeaturesListResult.getResults().length);
+        Assertions.assertEquals("custom-feature", paidUserFeaturesListResult.getResults()[0].getFeatureId());
         client.removeFeatureFromUser(customFeature, paidUser);
         Assertions.assertFalse(client.checkUserHasFeature(paidUser, "custom-feature", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForUser(paidUser, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForUser(paidUser, 100, requestOptions).getResults().length);
 
         // Assign 'feature-1' -> 'free' tier -> free user
         Assertions.assertFalse(client.checkUserHasFeature(freeUser, "feature-1", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, 1, requestOptions).length);
-        Assertions.assertEquals(0, client.listPricingTiersForUser(freeUser, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, requestOptions).getResults().length);
+        Assertions.assertEquals(0, client.listPricingTiersForUser(freeUser, 100, requestOptions).getResults().length);
         client.assignFeatureToPricingTier(feature1, freeTier);
         client.assignPricingTierToUser(freeTier, freeUser);
         Assertions.assertTrue(client.checkUserHasFeature(freeUser, "feature-1", requestOptions));
-        Feature[] freeTierFeatures = client.listFeaturesForPricingTier("free", 100, 1, requestOptions);
-        Assertions.assertEquals(1, freeTierFeatures.length);
-        Assertions.assertEquals("feature-1", freeTierFeatures[0].getFeatureId());
-        PricingTier[] freeUserTiers = client.listPricingTiersForUser(freeUser, 100, 1, requestOptions);
-        Assertions.assertEquals(1, freeUserTiers.length);
-        Assertions.assertEquals("free", freeUserTiers[0].getPricingTierId());
+        ListResult<Feature> freeTierFeaturesListResult = client.listFeaturesForPricingTier("free", 100, requestOptions);
+        Assertions.assertEquals(1, freeTierFeaturesListResult.getResults().length);
+        Assertions.assertEquals("feature-1", freeTierFeaturesListResult.getResults()[0].getFeatureId());
+        ListResult<PricingTier> freeUserTiersListResult = client.listPricingTiersForUser(freeUser, 100, requestOptions);
+        Assertions.assertEquals(1, freeUserTiersListResult.getResults().length);
+        Assertions.assertEquals("free", freeUserTiersListResult.getResults()[0].getPricingTierId());
         client.removeFeatureFromPricingTier(feature1, freeTier);
         Assertions.assertFalse(client.checkUserHasFeature(freeUser, "feature-1", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, 1, requestOptions).length);
-        Assertions.assertEquals(1, client.listPricingTiersForUser(freeUser, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, requestOptions).getResults().length);
+        Assertions.assertEquals(1, client.listPricingTiersForUser(freeUser, 100, requestOptions).getResults().length);
         client.removePricingTierFromUser(freeTier, freeUser);
-        Assertions.assertEquals(0, client.listPricingTiersForUser(freeUser, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listPricingTiersForUser(freeUser, 100, requestOptions).getResults().length);
 
         // Clean up
         client.deleteUser(freeUser);
@@ -404,35 +473,35 @@ public class LiveTest {
         // Assign 'custom-feature' -> paid tenant
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
         Assertions.assertFalse(client.checkTenantHasFeature(paidTenant, "custom-feature", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForTenant(paidTenant, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForTenant(paidTenant, 100, requestOptions).getResults().length);
         client.assignFeatureToTenant(customFeature, paidTenant);
         Assertions.assertTrue(client.checkTenantHasFeature(paidTenant, "custom-feature", requestOptions));
-        Feature[] paidTenantFeatures = client.listFeaturesForTenant(paidTenant, 100, 1, requestOptions);
-        Assertions.assertEquals(1, paidTenantFeatures.length);
-        Assertions.assertEquals("custom-feature", paidTenantFeatures[0].getFeatureId());
+        ListResult<Feature> paidTenantFeaturesListResult = client.listFeaturesForTenant(paidTenant, 100, requestOptions);
+        Assertions.assertEquals(1, paidTenantFeaturesListResult.getResults().length);
+        Assertions.assertEquals("custom-feature", paidTenantFeaturesListResult.getResults()[0].getFeatureId());
         client.removeFeatureFromTenant(customFeature, paidTenant);
         Assertions.assertFalse(client.checkTenantHasFeature(paidTenant, "custom-feature", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForTenant(paidTenant, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForTenant(paidTenant, 100, requestOptions).getResults().length);
 
         // Assign 'feature-1' -> 'free' tier -> free tenant
         Assertions.assertFalse(client.checkTenantHasFeature(freeTenant, "feature-1", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, 1, requestOptions).length);
-        Assertions.assertEquals(0, client.listPricingTiersForTenant(freeTenant, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, requestOptions).getResults().length);
+        Assertions.assertEquals(0, client.listPricingTiersForTenant(freeTenant, 100, requestOptions).getResults().length);
         client.assignFeatureToPricingTier(feature1, freeTier);
         client.assignPricingTierToTenant(freeTier, freeTenant);
         Assertions.assertTrue(client.checkTenantHasFeature(freeTenant, "feature-1", requestOptions));
-        Feature[] freeTierFeatures = client.listFeaturesForPricingTier("free", 100, 1, requestOptions);
-        Assertions.assertEquals(1, freeTierFeatures.length);
-        Assertions.assertEquals("feature-1", freeTierFeatures[0].getFeatureId());
-        PricingTier[] freeTenantTiers = client.listPricingTiersForTenant(freeTenant, 100, 1, requestOptions);
-        Assertions.assertEquals(1, freeTenantTiers.length);
-        Assertions.assertEquals("free", freeTenantTiers[0].getPricingTierId());
+        ListResult<Feature> freeTierFeaturesListResult = client.listFeaturesForPricingTier("free", 100, requestOptions);
+        Assertions.assertEquals(1, freeTierFeaturesListResult.getResults().length);
+        Assertions.assertEquals("feature-1", freeTierFeaturesListResult.getResults()[0].getFeatureId());
+        ListResult<PricingTier> freeTenantTiersListResult = client.listPricingTiersForTenant(freeTenant, 100, requestOptions);
+        Assertions.assertEquals(1, freeTenantTiersListResult.getResults().length);
+        Assertions.assertEquals("free", freeTenantTiersListResult.getResults()[0].getPricingTierId());
         client.removeFeatureFromPricingTier(feature1, freeTier);
         Assertions.assertFalse(client.checkTenantHasFeature(freeTenant, "feature-1", requestOptions));
-        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, 1, requestOptions).length);
-        Assertions.assertEquals(1, client.listPricingTiersForTenant(freeTenant, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listFeaturesForPricingTier("free", 100, requestOptions).getResults().length);
+        Assertions.assertEquals(1, client.listPricingTiersForTenant(freeTenant, 100, requestOptions).getResults().length);
         client.removePricingTierFromTenant(freeTier, freeTenant);
-        Assertions.assertEquals(0, client.listPricingTiersForTenant(freeTenant, 100, 1, requestOptions).length);
+        Assertions.assertEquals(0, client.listPricingTiersForTenant(freeTenant, 100, requestOptions).getResults().length);
 
         // Clean up
         client.deleteTenant(freeTenant);
@@ -474,13 +543,13 @@ public class LiveTest {
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
         WarrantFilters filters = new WarrantFilters().withObjectType("permission");
         ListParams listParams = new ListParams();
-        Warrant[] warrants = client.listWarrants(filters, listParams, requestOptions);
-        Assertions.assertEquals(2, warrants.length);
+        WarrantListResult warrantsListResult = client.listWarrants(filters, listParams, requestOptions);
+        Assertions.assertEquals(2, warrantsListResult.getResults().length);
 
         filters = filters.withObjectType("role");
-        warrants = client.listWarrants(filters, listParams,
+        warrantsListResult = client.listWarrants(filters, listParams,
                 requestOptions);
-        Assertions.assertEquals(1, warrants.length);
+        Assertions.assertEquals(1, warrantsListResult.getResults().length);
 
         client.deleteWarrant(permission1, "member", subject);
         client.deleteWarrant(permission2, "member", subject);
@@ -489,6 +558,30 @@ public class LiveTest {
         client.deletePermission(permission2);
         client.deleteRole(role1);
         client.deleteUser(user);
+    }
+
+    @Test
+    public void batchCreateAndDeleteWarrants() throws WarrantException {
+        Warrant[] createdWarrants = client.createWarrants(new Warrant[]{
+            new Warrant("permission", "perm1", "member", new WarrantSubject("user", "user1")),
+            new Warrant("permission", "perm2", "member", new WarrantSubject("user", "user1"))
+        });
+        Assertions.assertEquals(2, createdWarrants.length);
+
+        Assertions.assertTrue(client.check(new BaseWarrantObject("permission", "perm1"), "member", new WarrantSubject("user", "user1")));
+        Assertions.assertTrue(client.check(new BaseWarrantObject("permission", "perm2"), "member", new WarrantSubject("user", "user1")));
+
+        client.deleteWarrants(new Warrant[]{
+            new Warrant("permission", "perm1", "member", new WarrantSubject("user", "user1")),
+            new Warrant("permission", "perm2", "member", new WarrantSubject("user", "user1"))
+        });
+        client.deleteObjects(new BaseWarrantObject[]{
+            new BaseWarrantObject("permission", "perm1"),
+            new BaseWarrantObject("permission", "perm2"),
+            new BaseWarrantObject("user", "user1")
+        });
+
+        Assertions.assertEquals(0, client.listWarrants(new WarrantFilters(), new ListParams(), new RequestOptions().withWarrantToken("latest")).getResults().length);
     }
 
     @Test
@@ -590,7 +683,7 @@ public class LiveTest {
         Assertions.assertEquals("userA", resultSet.getResults()[0].getWarrant().getSubject().getObjectId());
 
         resultSet = client.query("select role where user:userA is member",
-                new ListParams().withLimit(1).withAfterId(resultSet.getLastId()));
+                new ListParams().withLimit(1).withNextCursor(resultSet.getNextCursor()));
         Assertions.assertEquals(1, resultSet.getResults().length);
         Assertions.assertEquals("role", resultSet.getResults()[0].getObjectType());
         Assertions.assertEquals("role2", resultSet.getResults()[0].getObjectId());

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -552,9 +552,12 @@ public class LiveTest {
         Role role1 = client.createRole(new Role("role1"));
 
         WarrantSubject subject = new WarrantSubject(user.type(), user.id());
-        client.createWarrant(permission1, "member", subject);
-        client.createWarrant(permission2, "member", subject);
-        client.createWarrant(role1, "member", subject);
+        Warrant perm1Warrant = client.createWarrant(permission1, "member", subject);
+        Warrant perm2Warrant = client.createWarrant(permission2, "member", subject);
+        Warrant role1Warrant = client.createWarrant(role1, "member", subject);
+        Assertions.assertNotNull(perm1Warrant.getWarrantToken());
+        Assertions.assertNotNull(perm2Warrant.getWarrantToken());
+        Assertions.assertNotNull(role1Warrant.getWarrantToken());
 
         RequestOptions requestOptions = new RequestOptions().withWarrantToken("latest");
         WarrantFilters filters = new WarrantFilters().withObjectType("permission");
@@ -567,9 +570,12 @@ public class LiveTest {
                 requestOptions);
         Assertions.assertEquals(1, warrantsListResult.getResults().length);
 
-        client.deleteWarrant(permission1, "member", subject);
-        client.deleteWarrant(permission2, "member", subject);
-        client.deleteWarrant(role1, "member", subject);
+        String warrantToken = client.deleteWarrant(permission1, "member", subject);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteWarrant(permission2, "member", subject);
+        Assertions.assertNotNull(warrantToken);
+        warrantToken = client.deleteWarrant(role1, "member", subject);
+        Assertions.assertNotNull(warrantToken);
         client.deletePermission(permission1);
         client.deletePermission(permission2);
         client.deleteRole(role1);

--- a/src/test/java/dev/warrant/LiveTest.java
+++ b/src/test/java/dev/warrant/LiveTest.java
@@ -249,15 +249,26 @@ public class LiveTest {
 
         BaseWarrantObjectListResult fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
         BaseWarrantObject[] fetchedObjects = fetchedObjectsList.getResults();
-        Assertions.assertEquals(2, fetchedObjects.length);
+        Assertions.assertEquals(3, fetchedObjects.length);
         Assertions.assertEquals(roleGeneratedId.getObjectType(), fetchedObjects[0].getObjectType());
         Assertions.assertEquals(roleGeneratedId.getObjectId(), fetchedObjects[0].getObjectId());
-        Assertions.assertEquals(updatedRole.getObjectType(), fetchedObjects[1].getObjectType());
-        Assertions.assertEquals(updatedRole.getObjectId(), fetchedObjects[1].getObjectId());
-        Assertions.assertEquals(updatedRole.getMeta(), fetchedObjects[1].getMeta());
+        Assertions.assertEquals(roleObject.getObjectType(), fetchedObjects[1].getObjectType());
+        Assertions.assertEquals(roleObject.getObjectId(), fetchedObjects[1].getObjectId());
+        Assertions.assertEquals(updatedRole.getObjectType(), fetchedObjects[2].getObjectType());
+        Assertions.assertEquals(updatedRole.getObjectId(), fetchedObjects[2].getObjectId());
+        Assertions.assertEquals(updatedRole.getMeta(), fetchedObjects[2].getMeta());
 
+        fetchedObjectsList = client.listObjects(new ObjectFilters().withQuery("manager"), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
+        Assertions.assertEquals(1, fetchedObjectsList.getResults().length);
+        Assertions.assertEquals(roleObject.getObjectType(), fetchedObjects[0].getObjectType());
+        Assertions.assertEquals(roleObject.getObjectId(), fetchedObjects[0].getObjectId());
+
+        client.deleteObject(roleObject);
         client.deleteObject(roleGeneratedId);
         client.deleteObject(roleWithMeta);
+
+        fetchedObjectsList = client.listObjects(new ObjectFilters(), new ListParams().withLimit(10).withSortBy("createdAt"), new RequestOptions().withWarrantToken("latest"));
+        Assertions.assertEquals(0, fetchedObjectsList.getResults().length);
     }
 
     @Test

--- a/src/test/java/dev/warrant/WarrantClientTest.java
+++ b/src/test/java/dev/warrant/WarrantClientTest.java
@@ -36,31 +36,31 @@ public class WarrantClientTest {
     public void testCreateUser() throws WarrantException {
         Mockito.when(httpResponse.statusCode()).thenReturn(200);
         Mockito.when(httpResponse.body())
-                .thenReturn("{\"userId\":\"sdf872934sdf\", \"createdAt\": \"2022-05-14T02:40:25Z\"}");
+                .thenReturn("{\"objectType\":\"user\", \"objectId\":\"sdf872934sdf\", \"createdAt\": \"2022-05-14T02:40:25Z\"}");
 
         WarrantClient warrantClient = new WarrantClient(WarrantConfig.withApiKey("sample_key"), httpClient);
         User newUser = warrantClient.createUser();
         Assertions.assertEquals("sdf872934sdf", newUser.getUserId());
-        Assertions.assertNull(newUser.getEmail());
+        Assertions.assertEquals("", newUser.getEmail());
     }
 
     @Test
     public void testCreateUserWithId() throws WarrantException {
         Mockito.when(httpResponse.statusCode()).thenReturn(200);
         Mockito.when(httpResponse.body())
-                .thenReturn("{\"userId\":\"sdf872935sdf\", \"createdAt\": \"2022-05-14T02:40:25Z\"}");
+                .thenReturn("{\"objectType\":\"user\", \"objectId\":\"sdf872935sdf\", \"createdAt\": \"2022-05-14T02:40:25Z\"}");
 
         WarrantClient warrantClient = new WarrantClient(WarrantConfig.withApiKey("sample_key"), httpClient);
         User newUser = warrantClient.createUser(new User("sdf872935sdf"));
         Assertions.assertEquals("sdf872935sdf", newUser.getUserId());
-        Assertions.assertNull(newUser.getEmail());
+        Assertions.assertEquals("", newUser.getEmail());
     }
 
     @Test
     public void testCreateUserWithIdAndEmail() throws WarrantException {
         Mockito.when(httpResponse.statusCode()).thenReturn(200);
         Mockito.when(httpResponse.body()).thenReturn(
-                "{\"userId\":\"sdf872934sdf\", \"email\": \"test@test.com\", \"createdAt\": \"2022-05-14T02:40:25Z\"}");
+                "{\"objectType\":\"user\", \"objectId\":\"sdf872934sdf\", \"meta\": {\"email\": \"test@test.com\"}, \"createdAt\": \"2022-05-14T02:40:25Z\"}");
 
         WarrantClient warrantClient = new WarrantClient(WarrantConfig.withApiKey("sample_key"), httpClient);
         User newUser = warrantClient.createUser(new User("sdf882934sdf", "test@test.com"));
@@ -72,24 +72,24 @@ public class WarrantClientTest {
     public void testCreateTenant() throws WarrantException {
         Mockito.when(httpResponse.statusCode()).thenReturn(200);
         Mockito.when(httpResponse.body()).thenReturn(
-                "{\"tenantId\": \"913241cf-740\", \"name\": null, \"createdAt\": \"2022-05-16T04:33:39Z\" }");
+                "{\"objectType\":\"tenant\", \"objectId\": \"913241cf-740\", \"createdAt\": \"2022-05-16T04:33:39Z\" }");
 
         WarrantClient warrantClient = new WarrantClient(WarrantConfig.withApiKey("sample_key"), httpClient);
         Tenant newTenant = warrantClient.createTenant();
         Assertions.assertEquals("913241cf-740", newTenant.getTenantId());
-        Assertions.assertNull(newTenant.getName());
+        Assertions.assertEquals("", newTenant.getName());
     }
 
     @Test
     public void testCreateTenantWithId() throws WarrantException {
         Mockito.when(httpResponse.statusCode()).thenReturn(200);
         Mockito.when(httpResponse.body())
-                .thenReturn("{\"tenantId\": \"913241cf\", \"name\": null, \"createdAt\": \"2022-05-16T04:33:39Z\" }");
+                .thenReturn("{\"objectType\":\"tenant\", \"objectId\": \"913241cf\", \"createdAt\": \"2022-05-16T04:33:39Z\" }");
 
         WarrantClient warrantClient = new WarrantClient(WarrantConfig.withApiKey("sample_key"), httpClient);
         Tenant newTenant = warrantClient.createTenant(new Tenant("913241cf"));
         Assertions.assertEquals("913241cf", newTenant.getTenantId());
-        Assertions.assertNull(newTenant.getName());
+        Assertions.assertEquals("", newTenant.getName());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class WarrantClientTest {
                 new QueryResult("role", "manager",
                         new Warrant("role", "manager", "member", new WarrantSubject("role", "admin")), true)
         };
-        QueryResultSet expectedQueryResultSet = new QueryResultSet(expectedQueryResults, "");
+        QueryResultSet expectedQueryResultSet = new QueryResultSet(expectedQueryResults, "", "");
 
         Assertions.assertEquals(expectedQueryResultSet.getResults().length, queryResultSet.getResults().length);
         Assertions.assertEquals(expectedQueryResultSet.getResults()[0].getObjectType(),

--- a/src/test/java/dev/warrant/WarrantClientTest.java
+++ b/src/test/java/dev/warrant/WarrantClientTest.java
@@ -2,9 +2,13 @@ package dev.warrant;
 
 import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.HashMap;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +32,11 @@ public class WarrantClientTest {
     public void init() throws IOException, InterruptedException {
         httpClient = Mockito.mock(HttpClient.class);
         httpResponse = Mockito.mock(HttpResponse.class);
+        BiPredicate<String, String> filter = (a, b) -> {
+                return true;
+        };
+        HttpHeaders mockHeaders = HttpHeaders.of(new HashMap<String,List<String>>(), filter);
+        Mockito.when(httpResponse.headers()).thenReturn(mockHeaders);
         Mockito.when(httpClient.send(Mockito.any(HttpRequest.class), Mockito.any(BodyHandler.class)))
                 .thenReturn(httpResponse);
     }


### PR DESCRIPTION
This PR makes changes to add support for the V2 endpoints of the Warrant API. 

Changes include:
- ObjectModule added for the object endpoints
- Batch create/delete support added for warrants
- List methods return a list result which includes an array of results along with an optional previous and next cursor for pagination
- Resource modules (e.g. `User`, `Role`) now include a meta field which contains metadata for the resource